### PR TITLE
fix CompatAsync(Throwing)Publisher missing implementation

### DIFF
--- a/Sources/Tetra/Combine/Combine+Concurrency.swift
+++ b/Sources/Tetra/Combine/Combine+Concurrency.swift
@@ -25,11 +25,11 @@ public extension Publisher {
     @available(tvOS, deprecated: 15.0, renamed: "values")
     @available(macOS, deprecated: 12.0, renamed: "values")
     @available(watchOS, deprecated: 8.0, renamed: "values")
-    var sequence:AnyAsyncTypeSequence<Output> {
+    var sequence: some AsyncTypedSequence<Output> {
         if #available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *) {
-            return AnyAsyncTypeSequence(base: values)
+            return values
         } else {
-            return AnyAsyncTypeSequence(base: CompatAsyncThrowingPublisher(publisher: self))
+            return CompatAsyncThrowingPublisher(publisher: self)
         }
     }
     
@@ -51,3 +51,5 @@ public extension Publisher where Failure == Never {
     }
     
 }
+
+

--- a/Sources/Tetra/Combine/CompatAsyncPublisher.swift
+++ b/Sources/Tetra/Combine/CompatAsyncPublisher.swift
@@ -30,8 +30,8 @@ public struct CompatAsyncPublisher<P:Publisher>: AsyncSequence where P.Failure =
         private let inner = AsyncSubscriber<P>()
         private let reference:AnyCancellable
         
-        public func next() async -> P.Output? {
-            await withTaskCancellationHandler(operation: inner.next) {
+        public mutating func next() async -> P.Output? {
+            await withTaskCancellationHandler(operation: inner.next) { [reference] in
                 reference.cancel()
             }
         }

--- a/Sources/Tetra/Combine/CompatAsyncPublisher.swift
+++ b/Sources/Tetra/Combine/CompatAsyncPublisher.swift
@@ -23,7 +23,7 @@ public struct CompatAsyncPublisher<P:Publisher>: AsyncSequence where P.Failure =
         self.publisher = publisher
     }
     
-    public struct Iterator: NonthrowingAsyncIteratorProtocol {
+    public struct Iterator: NonThrowingAsyncIteratorProtocol {
         
         public typealias Element = P.Output
         

--- a/Sources/Tetra/Combine/CompatAsyncPublisher.swift
+++ b/Sources/Tetra/Combine/CompatAsyncPublisher.swift
@@ -140,8 +140,8 @@ private final class AsyncSubscriber<P:Publisher> : Subscriber, Cancellable where
                 switch $0.status {
                 case .subscribed(_):
                     $0.pending.append(continuation)
-                    
                 case .awaitingSubscription:
+                    $0.pending.append(continuation)
                     $0.pendingDemand += 1
                 case .terminal:
                     break

--- a/Sources/Tetra/Combine/CompatAsyncThrowingPublisher.swift
+++ b/Sources/Tetra/Combine/CompatAsyncThrowingPublisher.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Combine
 
-public struct CompatAsyncThrowingPublisher<P:Publisher>: AsyncSequence {
+public struct CompatAsyncThrowingPublisher<P:Publisher>: AsyncTypedSequence {
 
     public typealias AsyncIterator = Iterator
     public typealias Element = P.Output
@@ -19,15 +19,15 @@ public struct CompatAsyncThrowingPublisher<P:Publisher>: AsyncSequence {
         Iterator(source: publisher)
     }
     
-    public struct Iterator: AsyncTypedIteratorProtocol {
+    public struct Iterator: AsyncIteratorProtocol {
         
         public typealias Element = P.Output
         
         private let inner = AsyncThrowingSubscriber<P>()
         private let reference:AnyCancellable
         
-        public func next() async throws -> P.Output? {
-            try await withTaskCancellationHandler(operation: inner.next) {
+        public mutating func next() async throws -> P.Output? {
+            try await withTaskCancellationHandler(operation: inner.next) { [reference] in
                 reference.cancel()
             }
         }
@@ -44,9 +44,6 @@ public struct CompatAsyncThrowingPublisher<P:Publisher>: AsyncSequence {
     }
 
 }
-
-
-
 
 private final class AsyncThrowingSubscriber<P:Publisher> : Subscriber, Cancellable {
     

--- a/Sources/Tetra/Combine/CompatAsyncThrowingPublisher.swift
+++ b/Sources/Tetra/Combine/CompatAsyncThrowingPublisher.swift
@@ -167,6 +167,7 @@ private final class AsyncThrowingSubscriber<P:Publisher> : Subscriber, Cancellab
                 let oldStatus = $0.state
                 switch oldStatus {
                 case .awaitingSubscription:
+                    $0.pending.append(continuation)
                     $0.pendingDemand += 1
                 case .subscribed(_):
                     $0.pending.append(continuation)

--- a/Sources/Tetra/Combine/Publishers+MapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+MapTask.swift
@@ -125,11 +125,13 @@ extension Publishers.MapTask {
                             }
                         }
                     }
-                    lock.withLockUnchecked{
-                        let oldValue = $0
-                        $0 = nil
-                        return oldValue
-                    }?.receive(completion: .finished)
+                    if !Task.isCancelled {
+                        lock.withLockUnchecked{
+                            let oldValue = $0
+                            $0 = nil
+                            return oldValue
+                        }?.receive(completion: .finished)
+                    }
                 } onCancel: {
                     subscription.cancel()
                     lock.withLock{ $0 = nil }

--- a/Sources/Tetra/Combine/Publishers+TryMapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+TryMapTask.swift
@@ -117,11 +117,13 @@ extension Publishers.TryMapTask {
                                 }
                             }
                         }
-                        lock.withLockUnchecked{
-                            let oldValue = $0
-                            $0 = nil
-                            return oldValue
-                        }?.receive(completion: .finished)
+                        if !Task.isCancelled {
+                            lock.withLockUnchecked{
+                                let oldValue = $0
+                                $0 = nil
+                                return oldValue
+                            }?.receive(completion: .finished)
+                        }
                     } catch {
                         lock.withLockUnchecked{
                             let oldValue = $0
@@ -129,11 +131,6 @@ extension Publishers.TryMapTask {
                             return oldValue
                         }?.receive(completion: .failure(error))
                     }
-                    lock.withLockUnchecked{
-                        let oldValue = $0
-                        $0 = nil
-                        return oldValue
-                    }?.receive(completion: .finished)
                 } onCancel: {
                     subscription.cancel()
                     lock.withLock{ $0 = nil }

--- a/Sources/Tetra/Concurrency/AsyncSequencePublisher.swift
+++ b/Sources/Tetra/Concurrency/AsyncSequencePublisher.swift
@@ -93,11 +93,13 @@ extension AsyncSequencePublisher {
                         }
                     }
                 }
-                lock.withLockUnchecked{
-                    let oldValue = $0
-                    $0 = nil
-                    return oldValue
-                }?.receive(completion: .finished)
+                if !Task.isCancelled {
+                    lock.withLockUnchecked{
+                        let oldValue = $0
+                        $0 = nil
+                        return oldValue
+                    }?.receive(completion: .finished)
+                }
             } catch {
                 lock.withLockUnchecked{
                     let oldValue = $0

--- a/Sources/Tetra/Concurrency/AsyncTypedSequence.swift
+++ b/Sources/Tetra/Concurrency/AsyncTypedSequence.swift
@@ -9,7 +9,7 @@ import Combine
 import _Concurrency
 
 @usableFromInline
-internal protocol NonthrowingAsyncIteratorProtocol<Element>: AsyncIteratorProtocol {
+internal protocol NonThrowingAsyncIteratorProtocol<Element>: AsyncIteratorProtocol {
     
     mutating func next() async -> Element?
     
@@ -21,7 +21,7 @@ public protocol AsyncTypedSequence<Element>:AsyncSequence {}
 extension AsyncThrowingPublisher: AsyncTypedSequence {}
 
 @available(iOS 15.0, tvOS 15.0, macCatalyst 15.0, watchOS 8.0, macOS 12.0, *)
-extension AsyncPublisher.Iterator: NonthrowingAsyncIteratorProtocol {}
+extension AsyncPublisher.Iterator: NonThrowingAsyncIteratorProtocol {}
 
 public struct WrappedAsyncSequence<Element>:AsyncSequence {
     
@@ -32,7 +32,7 @@ public struct WrappedAsyncSequence<Element>:AsyncSequence {
     public typealias AsyncIterator = Iterator
     private let builder: @Sendable () -> AsyncIterator
     
-    internal init<T:AsyncSequence>(base:T) where T.Element == Element, T.AsyncIterator: NonthrowingAsyncIteratorProtocol {
+    internal init<T:AsyncSequence>(base:T) where T.Element == Element, T.AsyncIterator: NonThrowingAsyncIteratorProtocol {
         builder = { [base] in
             Iterator(base: base.makeAsyncIterator())
         }
@@ -40,16 +40,15 @@ public struct WrappedAsyncSequence<Element>:AsyncSequence {
     
     public struct Iterator: AsyncIteratorProtocol {
         
-        private var iterator:any NonthrowingAsyncIteratorProtocol<Element>
+        private var iterator:any NonThrowingAsyncIteratorProtocol<Element>
         
         mutating public func next() async -> Element? {
             await iterator.next()
         }
         
-        internal init<T:NonthrowingAsyncIteratorProtocol>(base:T) where T.Element == Element {
+        internal init<T:NonThrowingAsyncIteratorProtocol>(base:T) where T.Element == Element {
             iterator = base
         }
     }
 }
-
 

--- a/Sources/Tetra/Concurrency/AsyncTypedSequence.swift
+++ b/Sources/Tetra/Concurrency/AsyncTypedSequence.swift
@@ -9,43 +9,19 @@ import Combine
 import _Concurrency
 
 @usableFromInline
-internal protocol AsyncTypedIteratorProtocol<Element>:AsyncIteratorProtocol {}
-
-@usableFromInline
 internal protocol NonthrowingAsyncIteratorProtocol<Element>: AsyncIteratorProtocol {
     
     mutating func next() async -> Element?
     
 }
 
-public struct AnyAsyncTypeSequence<Element>: AsyncSequence {
-    
-    private let builder:@Sendable () -> AsyncIterator
-    
-    public typealias AsyncIterator = Iterator
-    
-    internal init<T:AsyncSequence>(base:T) where T.Element == Element, T.AsyncIterator : AsyncTypedIteratorProtocol {
-        builder = { [base] in Iterator(base: base.makeAsyncIterator()) }
-    }
-    
-    public func makeAsyncIterator() -> AsyncIterator {
-        builder()
-    }
-    
-    public struct Iterator: AsyncTypedIteratorProtocol {
-        
-        public mutating func next() async throws -> Element? {
-            try await base.next()
-        }
-        
-        private var base:any AsyncTypedIteratorProtocol<Element>
-        
-        internal init<T:AsyncTypedIteratorProtocol>(base: T) where T.Element == Element {
-            self.base = base
-        }
-        
-    }
-}
+public protocol AsyncTypedSequence<Element>:AsyncSequence {}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
+extension AsyncThrowingPublisher: AsyncTypedSequence {}
+
+@available(iOS 15.0, tvOS 15.0, macCatalyst 15.0, watchOS 8.0, macOS 12.0, *)
+extension AsyncPublisher.Iterator: NonthrowingAsyncIteratorProtocol {}
 
 public struct WrappedAsyncSequence<Element>:AsyncSequence {
     
@@ -77,8 +53,3 @@ public struct WrappedAsyncSequence<Element>:AsyncSequence {
 }
 
 
-@available(iOS 15.0, tvOS 15.0, macCatalyst 15.0, watchOS 8.0, macOS 12.0, *)
-extension AsyncThrowingPublisher.Iterator: AsyncTypedIteratorProtocol {}
-
-@available(iOS 15.0, tvOS 15.0, macCatalyst 15.0, watchOS 8.0, macOS 12.0, *)
-extension AsyncPublisher.Iterator: NonthrowingAsyncIteratorProtocol{}

--- a/Sources/Tetra/Concurrency/Notification+AsyncSequence.swift
+++ b/Sources/Tetra/Concurrency/Notification+AsyncSequence.swift
@@ -29,7 +29,7 @@ public extension NotificationCenter {
 }
 
 @available(iOS 15.0, tvOS 15.0, macCatalyst 15.0, watchOS 8.0, macOS 12.0, *)
-extension NotificationCenter.Notifications.AsyncIterator: NonthrowingAsyncIteratorProtocol {}
+extension NotificationCenter.Notifications.AsyncIterator: NonThrowingAsyncIteratorProtocol {}
 
 public final class NotificationSequence: AsyncSequence {
     
@@ -44,7 +44,7 @@ public final class NotificationSequence: AsyncSequence {
     private let observer: NSObjectProtocol
     private let lock:some UnfairStateLock<NotficationState> = createUncheckedStateLock(uncheckedState: NotficationState())
     
-    public struct Iterator: NonthrowingAsyncIteratorProtocol {
+    public struct Iterator: NonThrowingAsyncIteratorProtocol {
         public typealias Element = Notification
         
         let parent:NotificationSequence


### PR DESCRIPTION
CompatAsync(Throwing)Publisher should collect continuation when awaiting Subscription.

CompatAsync(Throwing)Publisher no need to acquire lock to call finish when Task is cancelled.

fixed typo of naming of NonThrowingAsyncIteratorProtocol

expressed Compatible AsyncThrowingPublisher extension using `some` type erasure
