### PR TITLE
document about nested RunLoop in RunLoopScheduler

### DIFF
--- a/Sources/Tetra/Combine/RunLoopScheduler.swift
+++ b/Sources/Tetra/Combine/RunLoopScheduler.swift
@@ -15,8 +15,30 @@ import Combine
  
  this class runs RunLoop indefinitely in default Mode, until deinitialized.
  
- - important: Memory leaks found in instrument from this class are not acually leaked and they will be released as soon as `RunLoopScheduler`'s `Thread` terminate.
+ #1 Nested RunLoop
  
+ It's not a good idea to create nested RunLoop inside RunLoopScheduler but if you do need that do as follows. (otherwise RunLoopScheduler's Thread might never exit when needed)
+ 
+ case 1
+ ```
+ let scheduler = await RunLoopScheduler(async: (), config: .init(keepAliveUntilFinish: false))
+ scheduler.schedule{
+        RunLoop.current.run()
+ }
+ // keep strong reference to scheduler
+ 
+ 
+ ```
+ case 2
+ ```
+ let scheduler = await RunLoopScheduler(async: ())
+ scheduler.schedule{
+        RunLoop.current.perform{
+            RunLoop.current.run()
+        }
+ }
+ ```
+ - important: Memory leaks found in instrument from this class are not acually leaked and they will be released as soon as `RunLoopScheduler`'s `Thread` terminate.
  */
 public final class RunLoopScheduler: Scheduler, @unchecked Sendable, Hashable {
     

--- a/Sources/Tetra/Combine/RunLoopScheduler.swift
+++ b/Sources/Tetra/Combine/RunLoopScheduler.swift
@@ -130,7 +130,7 @@ public final class RunLoopScheduler: Scheduler, @unchecked Sendable, Hashable {
         }
         timer.tolerance = tolerance.timeInterval
         let cfTimer = timer as CFRunLoopTimer
-        CFRunLoopAddTimer(cfRunLoop, cfTimer, .defaultMode)
+        CFRunLoopAddTimer(cfRunLoop, cfTimer, .commonModes)
         return AnyCancellable{
             CFRunLoopTimerInvalidate(cfTimer)
         }
@@ -155,20 +155,20 @@ public final class RunLoopScheduler: Scheduler, @unchecked Sendable, Hashable {
             timer = .init(fire: date.date, interval: 0, repeats: false) { _ in action() }
         }
         timer.tolerance = tolerance.timeInterval
-        CFRunLoopAddTimer(cfRunLoop, timer as CFRunLoopTimer, .defaultMode)
+        CFRunLoopAddTimer(cfRunLoop, timer as CFRunLoopTimer, .commonModes)
     }
     
     @inlinable
     nonisolated
     public func schedule(options: SchedulerOptions?, _ action: @escaping () -> Void) {
         if config.keepAliveUntilFinish {
-            CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.defaultMode.rawValue) {
+            CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) {
                 action()
                 /// retain self until submitted task is finished
                 self.doNothing()
             }
         } else {
-            CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.defaultMode.rawValue, action)
+            CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue, action)
         }
         if CFRunLoopIsWaiting(cfRunLoop) {
             CFRunLoopWakeUp(cfRunLoop)
@@ -183,7 +183,7 @@ public final class RunLoopScheduler: Scheduler, @unchecked Sendable, Hashable {
     
     public func scheduleTask<T>(_ block: @escaping () throws -> T) async rethrows -> T {
         let result:Result<T,Error> = await withUnsafeContinuation{ continuation in
-            CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.defaultMode.rawValue) {
+            CFRunLoopPerformBlock(cfRunLoop, CFRunLoopMode.commonModes.rawValue) {
                 continuation.resume(returning: .init(catching: { try block() }))
             }
             if CFRunLoopIsWaiting(cfRunLoop) {

--- a/Sources/Tetra/SwiftUI/AsyncImage+BackPort.swift
+++ b/Sources/Tetra/SwiftUI/AsyncImage+BackPort.swift
@@ -35,11 +35,11 @@ public enum CompatAsyncImagePhase {
     }
 }
 
-@available(iOS, obsoleted: 15.0, renamed: "AsyncImage")
-@available(tvOS, obsoleted: 15.0, renamed: "AsyncImage")
-@available(macCatalyst, obsoleted: 15.0, renamed: "AsyncImage")
-@available(macOS, obsoleted: 12.0, renamed: "AsyncImage")
-@available(watchOS, obsoleted: 8.0, renamed: "AsyncImage")
+@available(iOS, deprecated: 15.0, renamed: "AsyncImage")
+@available(tvOS, deprecated: 15.0, renamed: "AsyncImage")
+@available(macCatalyst, deprecated: 15.0, renamed: "AsyncImage")
+@available(macOS, deprecated: 12.0, renamed: "AsyncImage")
+@available(watchOS, deprecated: 8.0, renamed: "AsyncImage")
 public struct CompatAsyncImage<Content: View>: View {
     
     @usableFromInline


### PR DESCRIPTION
document about nested RunLoop in RunLoopScheduler
RunLoopScheduler schedules in common mode to work with nested run loop in non default mode.
changed mark from obsolete to deprecated on CompatAsyncImage
