### PR TITLE
Task sleep using DispatchTimer

### DIFF
--- a/Sources/Tetra/Combine/Future+Concurrency.swift
+++ b/Sources/Tetra/Combine/Future+Concurrency.swift
@@ -8,13 +8,14 @@
 import Foundation
 import Combine
 
-extension Combine.Future where Failure == Never {
+public extension Combine.Future where Failure == Never {
     
     @available(iOS, deprecated: 15.0, renamed: "value")
     @available(iOS, deprecated: 15.0, renamed: "value")
     @available(iOS, deprecated: 15.0, renamed: "value")
     @available(watchOS, deprecated: 8, renamed: "value")
     @available(macOS, deprecated: 12.0, renamed: "value")
+    @inlinable
     final var compatValue: Output {
         get async {
             if #available(iOS 15.0, tvOS 15.0, macCatalyst 15.0, watchOS 8.0, macOS 12.0, *) {
@@ -43,13 +44,14 @@ extension Combine.Future where Failure == Never {
 }
 
 
-extension Combine.Future {
+public extension Combine.Future {
     
     @available(iOS, deprecated: 15.0, renamed: "value")
     @available(iOS, deprecated: 15.0, renamed: "value")
     @available(iOS, deprecated: 15.0, renamed: "value")
     @available(watchOS, deprecated: 8, renamed: "value")
     @available(macOS, deprecated: 12.0, renamed: "value")
+    @inlinable
     final var compatValue: Output {
         get async throws {
             if #available(iOS 15.0, tvOS 15.0, macCatalyst 15.0, watchOS 8.0, macOS 12.0, *) {

--- a/Sources/Tetra/Concurrency/Dispatch+Extension.swift
+++ b/Sources/Tetra/Concurrency/Dispatch+Extension.swift
@@ -1,0 +1,153 @@
+//
+//  Dispatch+Extension.swift
+//  
+//
+//  Created by pbk on 2023/01/26.
+//
+
+import Foundation
+import Dispatch
+
+public extension Task where Success == Never, Failure == Never {
+    
+    /**
+     Suspends the current task until the given deadline within a tolerance.
+     - Parameters:
+        - Throws: `CancellationError` if task is cancelled
+     */
+    @inlinable
+    static func sleep(until deadline:DispatchTime, tolerance:DispatchTimeInterval? = nil) async throws {
+        try await dispatchTimerSleep(wait: deadline, leeway: tolerance)
+    }
+    
+    /**
+     Suspends the current task until the given deadline within a tolerance.
+     - Parameters:
+        - Throws: `CancellationError` if task is cancelled
+     */
+    @inlinable
+    static func sleep(until wallDeadline:DispatchWallTime, tolerance:DispatchTimeInterval? = nil) async throws {
+        try await Task.sleep(nanoseconds: 1000)
+        try await dispatchTimerSleep(wait: wallDeadline, leeway: tolerance)
+    }
+    
+}
+
+
+@usableFromInline
+internal func dispatchTimerSleep(wait deadline:DispatchTime, leeway:DispatchTimeInterval?) async throws {
+    
+    let lock = createCheckedStateLock(checkedState: DispatchSleepState.waiting)
+    let source = DispatchSource.makeTimerSource(flags: [.strict])
+    source.schedule(deadline: deadline, repeating: .never, leeway: leeway ?? .nanoseconds(0))
+    source.setEventHandler{
+        lock.withLock{
+            $0.take()
+        }?.resume()
+    }
+    source.setCancelHandler{
+        lock.withLock{
+            $0.take()
+        }?.resume(throwing: CancellationError())
+    }
+    return try await withTaskCancellationHandler {
+        return try await withUnsafeThrowingContinuation{ continuation in
+            let snapShot = lock.withLock{
+                let oldValue = $0
+                switch oldValue {
+                case .finished:
+                    break
+                case .waiting, .continuation:
+                    $0 = .continuation(continuation)
+                    
+                }
+                return oldValue
+            }
+            switch snapShot {
+            case .continuation(let unsafeContinuation):
+                assertionFailure("reached unexpected state")
+                unsafeContinuation.resume(throwing: CancellationError())
+            case .finished:
+                continuation.resume(throwing: CancellationError())
+            case .waiting:
+                break
+            }
+            source.activate()
+        }
+    } onCancel: {
+        lock.withLock{
+            $0.take()
+        }?.resume(throwing: CancellationError())
+        source.cancel()
+    }
+
+}
+
+
+@usableFromInline
+internal func dispatchTimerSleep(wait wallDeadline:DispatchWallTime, leeway: DispatchTimeInterval?) async throws {
+    let lock = createCheckedStateLock(checkedState: DispatchSleepState.waiting)
+    let source = DispatchSource.makeTimerSource(flags: [.strict])
+    source.schedule(wallDeadline: wallDeadline, repeating: .never, leeway: leeway ?? .nanoseconds(0))
+    source.setEventHandler{
+        lock.withLock{
+            $0.take()
+        }?.resume()
+    }
+    source.setCancelHandler{
+        lock.withLock{
+            $0.take()
+        }?.resume(throwing: CancellationError())
+    }
+    return try await withTaskCancellationHandler {
+        return try await withUnsafeThrowingContinuation{ continuation in
+            let snapShot = lock.withLock{
+                let oldValue = $0
+                switch oldValue {
+                case .finished:
+                    break
+                case .waiting, .continuation:
+                    $0 = .continuation(continuation)
+                    
+                }
+                return oldValue
+            }
+            switch snapShot {
+            case .continuation(let unsafeContinuation):
+                assertionFailure("reached unexpected state")
+                unsafeContinuation.resume(throwing: CancellationError())
+            case .finished:
+                continuation.resume(throwing: CancellationError())
+            case .waiting:
+                break
+            }
+            source.activate()
+        }
+    } onCancel: {
+        lock.withLock{
+            $0.take()
+        }?.resume(throwing: CancellationError())
+        source.cancel()
+    }
+}
+
+
+
+private
+enum DispatchSleepState: Sendable {
+    
+    case waiting
+    case continuation(UnsafeContinuation<Void,Error>)
+    case finished
+    
+    mutating func take() -> UnsafeContinuation<Void,Error>? {
+        switch self {
+        case .waiting, .finished:
+            self = .finished
+            return nil
+        case .continuation(let unsafeContinuation):
+            self = .finished
+            return unsafeContinuation
+        }
+    }
+}


### PR DESCRIPTION
This PR provides a way to sleep current Task using DispatchTimer.
Which is very convenient where Clock protocol is unavailable.