### PR TITLE
prepare for xcode 15 and swift 5.9

### DIFF
--- a/Sources/Tetra/AsyncScope/InvalidTaskScope.swift
+++ b/Sources/Tetra/AsyncScope/InvalidTaskScope.swift
@@ -14,7 +14,7 @@ struct InvalidTaskScope: TaskScopeProtocol {
     var isCancelled:Bool { true }
     
     @usableFromInline
-    func launch(operation: @escaping Job) -> Bool {
+    func launch(operation: @escaping PendingWork) -> Bool {
         print("InvalidTaskScope never launch")
         return false
     }

--- a/Sources/Tetra/AsyncScope/JobSequence.swift
+++ b/Sources/Tetra/AsyncScope/JobSequence.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @usableFromInline
 struct JobSequence: Sendable, AsyncSequence {
-    
+
     @usableFromInline
     func makeAsyncIterator() -> AsyncIterator {
         stream.makeAsyncIterator()
@@ -25,14 +25,9 @@ struct JobSequence: Sendable, AsyncSequence {
     private let continuation:AsyncStream<Element>.Continuation
     
     init() {
-        var reference: AsyncStream<Element>.Continuation? = nil
-        let semaphore = DispatchSemaphore(value: 0)
-        stream = .init{ continuation in
-            reference = continuation
-            semaphore.signal()
-        }
-        semaphore.wait()
-        continuation = reference.unsafelyUnwrapped
+        let (source, ref) = AsyncStream<Element>.makeStream()
+        stream = source
+        continuation = ref
     }
     
     func append(job: __owned @escaping Element) -> Bool {

--- a/Sources/Tetra/AsyncScope/TaskScopeProtocol.swift
+++ b/Sources/Tetra/AsyncScope/TaskScopeProtocol.swift
@@ -9,7 +9,10 @@ import Foundation
 
 public protocol TaskScopeProtocol: Sendable, Hashable {
     
-    typealias Job = @Sendable () async -> Void
+    typealias PendingWork = @Sendable () async -> Void
+    
+    @available(*, deprecated, renamed: "PendingJob", message: "Job is deprecated since Swift has own type named Job")
+    typealias Job = PendingWork
     
     /**
      submit the Job to this `TaskScope`. Job will be executed on the next possible opportunity unless it's cancelled.

--- a/Sources/Tetra/AsyncScope/ViewBoundTaskScope.swift
+++ b/Sources/Tetra/AsyncScope/ViewBoundTaskScope.swift
@@ -12,7 +12,7 @@ public struct ViewBoundTaskScope: TaskScopeProtocol {
     
     @discardableResult
     @inlinable
-    public func launch(operation: @escaping Job) -> Bool {
+    public func launch(operation: @escaping PendingWork) -> Bool {
         switch scope {
         case .invalid:
             return InvalidTaskScope().launch(operation: operation)


### PR DESCRIPTION
- Change Typealias `Job` which conflict with new non-copyable struct type for Concurrency.

- use AsyncStream.makeStream for jobSequence

- use `DiscardingTaskGroup` which support discarding child task 