### PR TITLE
Fix availability check on withDiscardingTaskGroup

### DIFF
--- a/Sources/Tetra/AsyncScope/StandaloneTaskScope.swift
+++ b/Sources/Tetra/AsyncScope/StandaloneTaskScope.swift
@@ -94,7 +94,7 @@ public struct StandaloneTaskScope: TaskScopeProtocol {
             }
         }
         task = creator(priority) {
-            if #available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *) {
+            if #available(macOS 14, iOS 17, watchOS 10, tvOS 17, *) {
                 await withDiscardingTaskGroup { group in
                     group.addTask(priority: .background) {
                         await suspendUntilCancelled()

--- a/Sources/Tetra/AsyncScope/StandaloneTaskScope.swift
+++ b/Sources/Tetra/AsyncScope/StandaloneTaskScope.swift
@@ -94,7 +94,7 @@ public struct StandaloneTaskScope: TaskScopeProtocol {
             }
         }
         task = creator(priority) {
-            if #available(macOS 14, iOS 17, watchOS 10, tvOS 17, *) {
+            if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
                 await withDiscardingTaskGroup { group in
                     group.addTask(priority: .background) {
                         await suspendUntilCancelled()


### PR DESCRIPTION
withDiscardingTaskGroup is only available on macOS 14, iOS 17, tvOS 17 and so on, not at ios 16.4 and etc