### PR TITLE
Map precondition to EncodingError, introduce MultiMapTask

### DIFF
--- a/Sources/Tetra/Combine/Combine+Concurrency.swift
+++ b/Sources/Tetra/Combine/Combine+Concurrency.swift
@@ -11,13 +11,13 @@ import Combine
 public extension Publisher {
     
     @inlinable
-    func mapTask<T:Sendable>(transform: @escaping @Sendable (Output) async -> T) -> Publishers.MapTask<Self,T> where Output:Sendable {
-        Publishers.MapTask(upstream: self, transform: transform)
+    func mapTask<T:Sendable>(transform: @escaping @Sendable (Output) async -> T) -> MapTask<Self,T> where Output:Sendable {
+        MapTask(upstream: self, transform: transform)
     }
     
     @inlinable
-    func tryMapTask<T:Sendable>(transform: @escaping @Sendable (Output) async throws -> T) -> Publishers.TryMapTask<Self,T> where Output:Sendable {
-        Publishers.TryMapTask(upstream: self, transform: transform)
+    func tryMapTask<T:Sendable>(transform: @escaping @Sendable (Output) async throws -> T) -> TryMapTask<Self,T> where Output:Sendable {
+        TryMapTask(upstream: self, transform: transform)
     }
     
     @available(iOS, deprecated: 15.0, renamed: "values")

--- a/Sources/Tetra/Combine/ExperimentalMapTask.swift
+++ b/Sources/Tetra/Combine/ExperimentalMapTask.swift
@@ -1,0 +1,252 @@
+//
+//  File.swift
+//  
+//
+//  Created by 박병관 on 5/15/24.
+//
+
+import Foundation
+import Combine
+
+
+internal protocol CompatThrowingDiscardingTaskGroup {
+    
+    var isCancelled:Bool { get }
+    var isEmpty:Bool { get }
+    func cancelAll()
+    mutating func addTaskUnlessCancelled(
+        priority: TaskPriority?,
+        operation: @escaping @Sendable () async throws -> Void
+    ) -> Bool
+    mutating func addTask(
+        priority: TaskPriority?,
+        operation: @escaping @Sendable () async throws -> Void
+    )
+
+}
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, macCatalyst 17.0, visionOS 1.0, *)
+extension ThrowingDiscardingTaskGroup: CompatThrowingDiscardingTaskGroup {
+
+}
+
+extension ThrowingTaskGroup: CompatThrowingDiscardingTaskGroup where ChildTaskResult == Void {
+
+}
+
+/**
+    Manage Multiple Child Task. provides similair behavior of `flatMap`'s `maxPublisher`
+ */
+struct MultiMapTask<Upstream:Publisher, Output:Sendable>: Publisher where Upstream.Output:Sendable {
+    
+    public typealias Output = Output
+    public typealias Failure = Upstream.Failure
+
+    public let maxTasks:Subscribers.Demand
+    public let upstream:Upstream
+    public let transform:@Sendable (Upstream.Output) async -> Result<Output,Failure>
+    
+    public func receive<S>(subscriber: S) where S : Subscriber, Upstream.Failure == S.Failure, Output == S.Input {
+        subscriber
+            .receive(
+                subscription: Inner(
+                    maxTasks: maxTasks,
+                    upstream: upstream, 
+                    subscriber: subscriber,
+                    transform: transform
+                )
+            )
+    }
+}
+
+extension MultiMapTask {
+    
+    private final class Inner<S:Subscriber>:Subscription, CustomStringConvertible, CustomPlaygroundDisplayConvertible where S.Input == Output, S.Failure == Failure {
+        
+        var description: String { "MultiMapTask" }
+        
+        var playgroundDescription: Any { description }
+        typealias Stream = AsyncStream<Result<Upstream.Output,S.Failure>>
+        private let task:Task<Void,Never>
+        private let demander:DemandAsyncBuffer
+        
+        struct PendingDemandState {
+            var taskCount:Int
+            var pendingDemand:Subscribers.Demand
+        }
+        
+        // TODO: Replace with Delegating StateHolder
+        fileprivate init(
+            maxTasks:Subscribers.Demand,
+            upstream:Upstream,
+            subscriber:S,
+            transform: @escaping @Sendable (Upstream.Output) async -> Result<Output,Failure>
+        ) {
+            precondition(maxTasks != .none, "maxTasks can not be zero")
+            let buffer = DemandAsyncBuffer()
+            demander = buffer
+            let lock = createUncheckedStateLock(uncheckedState: S?.some(subscriber))
+            task = Task {
+                let subscriptionLock = createCheckedStateLock(checkedState: SubscriptionContinuation.waiting)
+                let demandState = createCheckedStateLock(checkedState: PendingDemandState(taskCount: 0, pendingDemand: .none))
+                let stream = Self.makeStream(upstream: upstream, receiveSubscription: subscriptionLock.received, onCancel: { buffer.close() })
+                guard let subscription = await subscriptionLock.consumeSubscription()
+                else { return }
+                func localTask(group: inout some CompatThrowingDiscardingTaskGroup) async {
+                    group.addTask(priority: nil) {
+                        for await demand in buffer {
+                            Self.processDemand(maxTasks: maxTasks, demand: demand, subscription: subscription, state: demandState)
+                        }
+                    }
+                    for await upstreamValue in stream {
+                        switch upstreamValue {
+                        case .failure(let failure):
+                            lock.withLockUnchecked{
+                                let old = $0
+                                $0 = nil
+                                return old
+                            }?.receive(completion: .failure(failure))
+                            break
+                        case .success(let success):
+                            let flag = group.addTaskUnlessCancelled(priority: nil) { [success] in
+                                switch await transform(success) {
+                                case .failure(let failure):
+                                    lock.withLockUnchecked{
+                                        let old = $0
+                                        $0 = nil
+                                        return old
+                                    }?.receive(completion: .failure(failure))
+                                    throw CancellationError()
+                                case .success(let value):
+                                    if let subscriber = lock.withLockUnchecked({ $0 }) {
+                                        let newDemand = subscriber.receive(value)
+                                        Self.processDemand(maxTasks: maxTasks, demand: newDemand, subscription: subscription, state: demandState, reduce: true)
+                                    } else {
+                                        throw CancellationError()
+                                    }
+                                }
+                                
+                            }
+                            if !flag {
+                                break
+                            }
+                        }
+                    }
+                }
+                await withTaskCancellationHandler {
+                    if #available(iOS 17.0, tvOS 17.0, macCatalyst 17.0, macOS 14.0, watchOS 10.0, visionOS 1.0, *) {
+                        try? await withThrowingDiscardingTaskGroup(returning: Void.self) { group in
+                            await localTask(group: &group)
+                        }
+                    } else {
+                        await withThrowingTaskGroup(of: Void.self, returning: Void.self) { group in
+                            let gIterator = group.makeAsyncIterator()
+                            async let subTask:() = {
+                                var iterator = gIterator
+                                while let _ = try? await iterator.next() {
+                                    
+                                }
+                            }()
+                            await localTask(group: &group)
+                            await subTask
+                        }
+                    }
+
+                } onCancel: {
+                    subscription.cancel()
+                    lock.withLock{ $0 = nil }
+                }
+                lock.withLockUnchecked{
+                    let oldValue = $0
+                    $0 = nil
+                    return oldValue
+                }?.receive(completion: .finished)
+                buffer.close()
+            }
+        }
+        
+        func cancel() {
+            task.cancel()
+        }
+        
+        func request(_ demand: Subscribers.Demand) {
+            demander.append(element: demand)
+        }
+        
+        deinit { task.cancel() }
+        
+        static func makeStream(
+            upstream:Upstream,
+            receiveSubscription: @escaping (any Subscription) -> Void,
+            onCancel: @escaping @Sendable () -> Void
+        ) -> Stream {
+            return Stream { continuation in
+                continuation.onTermination = { _ in
+                    onCancel()
+                }
+                upstream.subscribe(
+                    AnySubscriber(
+                        receiveSubscription: receiveSubscription,
+                        receiveValue: {
+                            continuation.yield(.success($0))
+                            return .none
+                        },
+                        receiveCompletion: {
+                            switch $0 {
+                            case .finished:
+                                break
+                            case .failure(let error):
+                                continuation.yield(.failure(error))
+                            }
+                            continuation.finish()
+                        }
+                    )
+                )
+            }
+        }
+        
+        static func processDemand(
+            maxTasks: Subscribers.Demand,
+            demand:Subscribers.Demand,
+            subscription: any Subscription,
+            state: some UnfairStateLock<PendingDemandState>,
+            reduce:Bool = false
+        ) {
+            if maxTasks == .unlimited {
+                if demand > .none {
+                    subscription.request(demand)
+                }
+            } else {
+                let newDemand = state.withLock{
+                    if reduce {
+                        $0.taskCount -= 1
+                    }
+                    $0.pendingDemand += demand
+                    let availableSpace = maxTasks - $0.taskCount
+                    if $0.pendingDemand >= availableSpace {
+                        $0.pendingDemand -= availableSpace
+                        if let maxCount = availableSpace.max {
+                            $0.taskCount += maxCount
+                        } else {
+                            fatalError("availableSpace can not be unlimited while limit is bounded")
+                        }
+                        return availableSpace
+                    } else {
+                        let snapShot = $0.pendingDemand
+                        if let count = snapShot.max {
+                            $0.taskCount += count
+                        } else {
+                            // pendingDemand is smaller than availableSpace and limit is bounded and pendingDemand is infinite
+                            fatalError("pendingDemand can not be unlimited while limit is bounded")
+                        }
+                        return snapShot
+                    }
+                }
+                if newDemand > .none {
+                    subscription.request(newDemand)
+                }
+            }
+        }
+    }
+    
+    
+}

--- a/Sources/Tetra/Combine/Publishers+MapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+MapTask.swift
@@ -57,6 +57,7 @@ extension MapTask {
         private let task:Task<Void,Never>
         private let demander:DemandAsyncBuffer
         
+        // TODO: Replace with Delegating StateHolder
         fileprivate init(
             upstream:Upstream,
             subscriber:S,

--- a/Sources/Tetra/Combine/Publishers+MapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+MapTask.swift
@@ -8,43 +8,45 @@
 import Foundation
 import Combine
 
-extension Publishers {
-    /**
-     
-        underlying task will receive task cancellation signal if the subscription is cancelled
-     
-     */
-    public struct MapTask<Upstream:Publisher, Output:Sendable>: Publisher where Upstream.Output:Sendable {
+/**
+ 
+    underlying task will receive task cancellation signal if the subscription is cancelled
+ 
+ */
+public struct MapTask<Upstream:Publisher, Output:Sendable>: Publisher where Upstream.Output:Sendable {
 
-        public typealias Output = Output
-        public typealias Failure = Upstream.Failure
+    public typealias Output = Output
+    public typealias Failure = Upstream.Failure
 
-        public let upstream:Upstream
-        public var transform:@Sendable (Upstream.Output) async -> Output
+    public let upstream:Upstream
+    public var transform:@Sendable (Upstream.Output) async -> Result<Output,Failure>
 
-        public init(upstream: Upstream, transform: @escaping @Sendable (Upstream.Output) async -> Output) {
-            self.upstream = upstream
-            self.transform = transform
+    public init(upstream: Upstream, transform: @escaping @Sendable (Upstream.Output) async -> Output) {
+        self.upstream = upstream
+        self.transform = {
+            Result.success(await transform($0))
         }
+    }
+    
+    public init(upstream: Upstream, transform: @escaping @Sendable (Upstream.Output) async -> Result<Output,Failure>) {
+        self.upstream = upstream
+        self.transform = transform
+    }
 
-        public func receive<S>(subscriber: S) where S : Subscriber, Upstream.Failure == S.Failure, Output == S.Input {
-            subscriber
-                .receive(
-                    subscription: Inner(
-                        upstream: upstream, subscriber: subscriber, transform: transform
-                    )
+    public func receive<S>(subscriber: S) where S : Subscriber, Upstream.Failure == S.Failure, Output == S.Input {
+        subscriber
+            .receive(
+                subscription: Inner(
+                    upstream: upstream, subscriber: subscriber, transform: transform
                 )
-        }
-        
+            )
     }
     
 }
 
-extension Publishers.MapTask: Sendable where Upstream: Sendable {}
+extension MapTask: Sendable where Upstream: Sendable {}
 
-extension Publishers.MapTask {
-    
-    
+extension MapTask {
     
     private final class Inner<S:Subscriber>:Subscription, CustomStringConvertible, CustomPlaygroundDisplayConvertible where S.Input == Output, S.Failure == Failure {
         
@@ -55,78 +57,61 @@ extension Publishers.MapTask {
         private let task:Task<Void,Never>
         private let demander:DemandAsyncBuffer
         
-        fileprivate init(upstream:Upstream, subscriber:S, transform: @escaping @Sendable (Upstream.Output) async -> Output) {
+        fileprivate init(
+            upstream:Upstream,
+            subscriber:S,
+            transform: @escaping @Sendable (Upstream.Output) async -> Result<Output,Failure>
+        ) {
             let buffer = DemandAsyncBuffer()
             let lock = createUncheckedStateLock(uncheckedState: S?.some(subscriber))
             demander = buffer
             task = Task {
                 let subscriptionLock = createCheckedStateLock(checkedState: SubscriptionContinuation.waiting)
-                let stream = AsyncStream<Result<Upstream.Output,Failure>>{ continuation in
-                    upstream.subscribe(
-                        AnySubscriber(
-                            receiveSubscription: subscriptionLock.received,
-                            receiveValue: {
-                                continuation.yield(.success($0))
-                                return .none
-                            },
-                            receiveCompletion: {
-                                switch $0 {
-                                case .finished:
-                                    break
-                                case .failure(let error):
-                                    continuation.yield(.failure(error))
-                                }
-                                continuation.finish()
-                            }
-                        )
-                    )
-                    continuation.onTermination = {
-                        if case .cancelled = $0 {
-                            buffer.close()
-                        }
-                    }
-                }
+                let stream = Self.makeStream(
+                    upstream: upstream,
+                    receiveSubscription: subscriptionLock.received,
+                    onCancel: { buffer.close() },
+                    transform: transform
+                )
                 guard let subscription = await subscriptionLock.consumeSubscription()
                 else { return }
                 await withTaskCancellationHandler {
                     var iterator = stream.makeAsyncIterator()
-                completionLabel:
                     for await demand in buffer {
                         var pending = demand
                         while pending > .none {
                             pending -= 1
                             subscription.request(.max(1))
-                            if let result = await iterator.next() {
-                                switch result {
-                                case .success(let value):
-                                    let transformedValue = await transform(value)
-                                    if let currentSubscriber = lock.withLockUnchecked({ $0 }) {
-                                        pending += currentSubscriber.receive(transformedValue)
-                                    } else {
-                                        break completionLabel
-                                    }
-                                case .failure(let failure):
-                                    lock.withLockUnchecked{
-                                        let oldValue = $0
-                                        $0 = nil
-                                        return oldValue
-                                    }?.receive(completion: .failure(failure))
-                                    break completionLabel
+                            guard let result = await iterator.next() else {
+                                return
+                            }
+                            switch result {
+                            case .success(let value):
+                                if let currentSubscriber = lock.withLockUnchecked({ $0 }) {
+                                    pending += currentSubscriber.receive(value)
+                                } else {
+                                    return
                                 }
-                            } else {
-                                break completionLabel
+                            case .failure(let failure):
+                                lock.withLockUnchecked{
+                                    let oldValue = $0
+                                    $0 = nil
+                                    return oldValue
+                                }?.receive(completion: .failure(failure))
+                                return
                             }
                         }
                     }
-                    lock.withLockUnchecked{
-                        let oldValue = $0
-                        $0 = nil
-                        return oldValue
-                    }?.receive(completion: .finished)
+
                 } onCancel: {
                     subscription.cancel()
                     lock.withLock{ $0 = nil }
                 }
+                lock.withLockUnchecked{
+                    let oldValue = $0
+                    $0 = nil
+                    return oldValue
+                }?.receive(completion: .finished)
                 buffer.close()
             }
         }
@@ -140,7 +125,54 @@ extension Publishers.MapTask {
         }
         
         deinit { task.cancel() }
+        
+        static func makeStream(
+            upstream:Upstream,
+            receiveSubscription: @escaping (any Subscription) -> Void,
+            onCancel: @escaping @Sendable () -> Void,
+            transform:@escaping @Sendable (Upstream.Output) async -> Result<Output,Failure>
+        ) -> AsyncMapSequence<AsyncStream<Result<Upstream.Output,Failure>>,Result<Output,Failure>> {
+            let stream = AsyncStream<Result<Upstream.Output,Failure>>{ continuation in
+                upstream.subscribe(
+                    AnySubscriber(
+                        receiveSubscription: receiveSubscription,
+                        receiveValue: {
+                            continuation.yield(.success($0))
+                            return .none
+                        },
+                        receiveCompletion: {
+                            switch $0 {
+                            case .finished:
+                                break
+                            case .failure(let error):
+                                continuation.yield(.failure(error))
+                            }
+                            continuation.finish()
+                        }
+                    )
+                )
+                continuation.onTermination = {
+                    if case .cancelled = $0 {
+                        onCancel()
+                    }
+                }
+            }.map{
+                switch $0 {
+                case .success(let success):
+                    return await transform(success)
+                case .failure(let failure):
+                    return .failure(failure)
+                }
+            }
+            return stream
+        }
 
     }
+    
+}
+
+extension Publishers {
+    
+    typealias MapTask = Tetra.MapTask
     
 }

--- a/Sources/Tetra/Combine/Publishers+TryMapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+TryMapTask.swift
@@ -9,43 +9,38 @@ import Foundation
 import Combine
 import _Concurrency
 
-extension Publishers {
+/**
+ 
+    underlying task will receive task cancellation signal if the subscription is cancelled
+ 
+ */
+public struct TryMapTask<Upstream:Publisher, Output:Sendable>: Publisher where Upstream.Output:Sendable {
 
-    /**
-     
-        underlying task will receive task cancellation signal if the subscription is cancelled
-     
-     */
-    public struct TryMapTask<Upstream:Publisher, Output:Sendable>: Publisher where Upstream.Output:Sendable {
+    public typealias Output = Output
+    public typealias Failure = Error
 
-        public typealias Output = Output
-        public typealias Failure = Error
+    public let upstream:Upstream
+    public var transform:@Sendable (Upstream.Output) async throws -> Output
 
-        public let upstream:Upstream
-        public var transform:@Sendable (Upstream.Output) async throws -> Output
-
-        public init(upstream: Upstream, transform: @escaping @Sendable (Upstream.Output) async throws -> Output) {
-            self.upstream = upstream
-            self.transform = transform
-        }
-        
-        public func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
-            subscriber
-                .receive(
-                    subscription: Inner(
-                        upstream: upstream, subscriber: subscriber, transform: transform
-                    )
+    public init(upstream: Upstream, transform: @escaping @Sendable (Upstream.Output) async throws -> Output) {
+        self.upstream = upstream
+        self.transform = transform
+    }
+    
+    public func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
+        subscriber
+            .receive(
+                subscription: Inner(
+                    upstream: upstream, subscriber: subscriber, transform: transform
                 )
-        }
-
+            )
     }
 
 }
 
+extension TryMapTask: Sendable where Upstream: Sendable {}
 
-extension Publishers.TryMapTask: Sendable where Upstream: Sendable {}
-
-extension Publishers.TryMapTask {
+extension TryMapTask {
     
     private final class Inner<S:Subscriber>:Subscription, CustomStringConvertible, CustomPlaygroundDisplayConvertible where S.Input == Output, S.Failure == Failure {
         
@@ -62,59 +57,31 @@ extension Publishers.TryMapTask {
             demander = buffer
             task = Task {
                 let subscriptionLock = createCheckedStateLock(checkedState: SubscriptionContinuation.waiting)
-                let stream = AsyncThrowingStream<Upstream.Output,Failure> { continuation in
-                    continuation.onTermination = {
-                        if case .cancelled = $0 {
-                            buffer.close()
-                        }
-                    }
-                    upstream
-                        .subscribe(
-                            AnySubscriber(
-                                receiveSubscription: subscriptionLock.received,
-                                receiveValue: {
-                                    continuation.yield($0)
-                                    return .none
-                                },
-                                receiveCompletion: {
-                                    switch $0 {
-                                    case .finished:
-                                        continuation.finish(throwing: .none)
-                                    case .failure(let error):
-                                        continuation.finish(throwing: error)
-                                    }
-                                }
-                            )
-                        )
-                }
+                let stream = Self.makeStream(
+                    upstream: upstream,
+                    receiveSubscription: subscriptionLock.received,
+                    onCancel: { buffer.close() },
+                    transform: transform
+                )
                 guard let subscription = await subscriptionLock.consumeSubscription()
                 else { return }
                 await withTaskCancellationHandler {
                     var iterator = stream.makeAsyncIterator()
                     do {
-                    completionLabel:
                         for await demand in buffer {
                             var pending = demand
                             while pending > .none {
-                                pending -= 1
-                                subscription.request(.max(1))
-                                if let upstreamValue = try await iterator.next() {
-                                    let value = try await transform(upstreamValue)
-                                    if let currentSubscriber = lock.withLockUnchecked({ $0 }) {
-                                        pending += currentSubscriber.receive(value)
-                                    } else {
-                                        break completionLabel
-                                    }
-                                } else {
-                                    break completionLabel
+                                subscription.request(pending)
+                                pending = .none
+                                guard 
+                                    let value = try await iterator.next(),
+                                    let currentSubscriber = lock.withLockUnchecked({ $0 })
+                                else {
+                                    return
                                 }
+                                pending += currentSubscriber.receive(value)
                             }
                         }
-                        lock.withLockUnchecked{
-                            let oldValue = $0
-                            $0 = nil
-                            return oldValue
-                        }?.receive(completion: .finished)
                     } catch {
                         lock.withLockUnchecked{
                             let oldValue = $0
@@ -126,6 +93,11 @@ extension Publishers.TryMapTask {
                     subscription.cancel()
                     lock.withLock{ $0 = nil }
                 }
+                lock.withLockUnchecked{
+                    let oldValue = $0
+                    $0 = nil
+                    return oldValue
+                }?.receive(completion: .finished)
                 buffer.close()
             }
         }
@@ -141,7 +113,47 @@ extension Publishers.TryMapTask {
         deinit {
             task.cancel()
         }
+        
+        static func makeStream(
+            upstream:Upstream,
+            receiveSubscription: @escaping (any Subscription) -> Void,
+            onCancel: @escaping @Sendable () -> Void,
+            transform:@escaping @Sendable (Upstream.Output) async throws -> Output
+        ) -> AsyncThrowingMapSequence<AsyncThrowingStream<Upstream.Output,Failure>, Output> {
+            return AsyncThrowingStream<Upstream.Output,Failure> { continuation in
+                continuation.onTermination = {
+                    if case .cancelled = $0 {
+                        onCancel()
+                    }
+                }
+                upstream
+                    .subscribe(
+                        AnySubscriber(
+                            receiveSubscription: receiveSubscription,
+                            receiveValue: {
+                                continuation.yield($0)
+                                return .none
+                            },
+                            receiveCompletion: {
+                                switch $0 {
+                                case .finished:
+                                    continuation.finish(throwing: .none)
+                                case .failure(let error):
+                                    continuation.finish(throwing: error)
+                                }
+                            }
+                        )
+                    )
+            }.map{
+                try await transform($0)
+            }
+        }
 
     }
     
+}
+
+extension Publishers {
+    
+    typealias TryMapTask = Tetra.TryMapTask
 }

--- a/Sources/Tetra/Combine/Publishers+TryMapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+TryMapTask.swift
@@ -51,6 +51,7 @@ extension TryMapTask {
         private let task:Task<Void,Never>
         private let demander:DemandAsyncBuffer
         
+        // TODO: Replace with Delegating StateHolder
         fileprivate init(upstream:Upstream, subscriber:S, transform: @escaping @Sendable (Upstream.Output) async throws -> Output) {
             let buffer = DemandAsyncBuffer()
             let lock = createUncheckedStateLock(uncheckedState: S?.some(subscriber))

--- a/Sources/Tetra/Concurrency/AsyncTypedSequence.swift
+++ b/Sources/Tetra/Concurrency/AsyncTypedSequence.swift
@@ -14,7 +14,8 @@ internal protocol NonThrowingAsyncIteratorProtocol<Element>: AsyncIteratorProtoc
     mutating func next() async -> Element?
     
 }
-
+internal protocol NonThrowingAsyncSequence<Element>: AsyncSequence where AsyncIterator:NonThrowingAsyncIteratorProtocol<Element> {
+}
 public protocol AsyncTypedSequence<Element>:AsyncSequence {}
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)
@@ -22,7 +23,8 @@ extension AsyncThrowingPublisher: AsyncTypedSequence {}
 
 @available(iOS 15.0, tvOS 15.0, macCatalyst 15.0, watchOS 8.0, macOS 12.0, *)
 extension AsyncPublisher.Iterator: NonThrowingAsyncIteratorProtocol {}
-
+extension AsyncStream.Iterator: NonThrowingAsyncIteratorProtocol {}
+extension AsyncStream: NonThrowingAsyncSequence {}
 public struct WrappedAsyncSequence<Element>:AsyncSequence {
     
     public func makeAsyncIterator() -> Iterator {

--- a/Sources/Tetra/Concurrency/AsyncTypedSequence.swift
+++ b/Sources/Tetra/Concurrency/AsyncTypedSequence.swift
@@ -14,8 +14,11 @@ internal protocol NonThrowingAsyncIteratorProtocol<Element>: AsyncIteratorProtoc
     mutating func next() async -> Element?
     
 }
-internal protocol NonThrowingAsyncSequence<Element>: AsyncSequence where AsyncIterator:NonThrowingAsyncIteratorProtocol<Element> {
+
+@usableFromInline
+internal protocol NonThrowingAsyncSequence<Element>: AsyncSequence where AsyncIterator: NonThrowingAsyncIteratorProtocol<Element> {
 }
+
 public protocol AsyncTypedSequence<Element>:AsyncSequence {}
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, tvOS 15.0, watchOS 8.0, *)

--- a/Sources/Tetra/Concurrency/DemandAsyncBuffer.swift
+++ b/Sources/Tetra/Concurrency/DemandAsyncBuffer.swift
@@ -26,14 +26,9 @@ struct DemandAsyncBuffer: AsyncSequence, Sendable {
     private let continuation: AsyncStream<Element>.Continuation
     
     init() {
-        var reference:AsyncStream<Element>.Continuation? = nil
-        let semaphore = DispatchSemaphore(value: 0)
-        stream = .init{
-            reference = $0
-            semaphore.signal()
-        }
-        semaphore.wait()
-        continuation = reference.unsafelyUnwrapped
+        let tuple  = AsyncStream<Element>.makeStream()
+        stream = tuple.stream
+        continuation = tuple.continuation
     }
     
     func append(element: __owned Element) {

--- a/Sources/Tetra/Foundation/Codable/InvalidEncodingContainer.swift
+++ b/Sources/Tetra/Foundation/Codable/InvalidEncodingContainer.swift
@@ -1,0 +1,104 @@
+//
+//  File.swift
+//  
+//
+//  Created by 박병관 on 5/5/24.
+//
+
+import Foundation
+
+struct InvalidEncoder: Encoder {
+    //    context where actual invalid behavior happen
+    let context:EncodingError.Context
+    var codingPath: [any CodingKey]
+    
+    var userInfo: [CodingUserInfoKey : Any] { [:]}
+    
+    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+        return .init(InvalidKeyedEncodingContainer(context: context, codingPath: codingPath))
+    }
+    
+    func unkeyedContainer() -> any UnkeyedEncodingContainer {
+        return InvalidUnkeyedEncodingContainer(context: context, codingPath: codingPath)
+    }
+    
+    func singleValueContainer() -> any SingleValueEncodingContainer {
+        return InvalidSingleEncodingContainer(context: context, codingPath: codingPath)
+    }
+    
+}
+
+struct InvalidSingleEncodingContainer: SingleValueEncodingContainer  {
+    //    context where actual invalid behavior happen
+    let context:EncodingError.Context
+    var codingPath: [any CodingKey]
+    
+    func encodeNil() throws {
+        throw EncodingError.invalidValue(Optional<Any>.none as Any, context)
+    }
+
+    func encode<T>(_ value: T) throws where T : Encodable {
+        throw EncodingError.invalidValue(value, context)
+    }
+}
+
+struct InvalidUnkeyedEncodingContainer: UnkeyedEncodingContainer {
+    //    context where actual invalid behavior happen
+    let context:EncodingError.Context
+    var codingPath: [any CodingKey]
+    
+    var count: Int { 0 }
+    
+    func encodeNil() throws {
+        throw EncodingError.invalidValue(Optional<Any>.none as Any, context)
+    }
+    
+    func encode<T>(_ value: T) throws where T : Encodable {
+        throw EncodingError.invalidValue(value, context)
+    }
+    
+    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        return .init(InvalidKeyedEncodingContainer(context: context, codingPath: codingPath))
+    }
+    
+    func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
+        return self
+    }
+    
+    func superEncoder() -> any Encoder {
+        return InvalidEncoder(context: context, codingPath: codingPath + [TetraCodingKey.super])
+    }
+    
+}
+
+struct InvalidKeyedEncodingContainer<Key:CodingKey>: KeyedEncodingContainerProtocol {
+    let context:EncodingError.Context
+    var codingPath: [any CodingKey]
+    
+    func encodeNil(forKey key: Key) throws {
+        throw EncodingError.invalidValue(Optional<Any>.none as Any, context)
+    }
+    
+    func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
+        throw EncodingError.invalidValue(value, context)
+    }
+    
+    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        return .init(InvalidKeyedEncodingContainer<NestedKey>(context: context, codingPath: codingPath + [key]))
+    }
+    
+    func nestedUnkeyedContainer(forKey key: Key) -> any UnkeyedEncodingContainer {
+        return InvalidUnkeyedEncodingContainer(context: context, codingPath: codingPath + [key])
+    }
+    
+    func superEncoder() -> any Encoder {
+        return InvalidEncoder(context: context, codingPath: codingPath + [TetraCodingKey.super])
+    }
+    
+    func superEncoder(forKey key: Key) -> any Encoder {
+        return InvalidEncoder(context: context, codingPath: codingPath + [key])
+    }
+    
+}
+
+

--- a/Sources/Tetra/Foundation/Codable/PlistWrapperEncoder.swift
+++ b/Sources/Tetra/Foundation/Codable/PlistWrapperEncoder.swift
@@ -114,7 +114,8 @@ extension PlistWrapperEncoder.EncoderImp: Encoder {
             let container = PlistWrapperEncoder.KeyedEncoder<Key>(codingPath: codingPath, userInfo: userInfo, ref: ref)
             return .init(container)
         default:
-            preconditionFailure("Attempt to create new keyed encoding container when already previously encoded at this path.")
+            let context = EncodingError.Context(codingPath: codingPath, debugDescription: "Attempt to create new keyed encoding container when already previously encoded at this path.")
+            return .init(InvalidKeyedEncodingContainer(context: context, codingPath: codingPath))
         }
     }
     
@@ -130,12 +131,16 @@ extension PlistWrapperEncoder.EncoderImp: Encoder {
         case .array(_):
             return PlistWrapperEncoder.UnkeyedEncoder(codingPath: codingPath, userInfo: userInfo, ref: ref)
         default:
-            preconditionFailure("Attempt to create new unkeyed encoding container when already previously encoded at this path.")
+            let context = EncodingError.Context(codingPath: codingPath, debugDescription: "Attempt to create new unkeyed encoding container when already previously encoded at this path.")
+            return InvalidUnkeyedEncodingContainer(context: context, codingPath: codingPath)
         }
     }
     
     func singleValueContainer() -> SingleValueEncodingContainer {
-        precondition(ref.backing == nil, "Attempt to create new single encoding container when already previously encoded at this path.")
+        if ref.backing != nil {
+            let context = EncodingError.Context(codingPath: codingPath, debugDescription: "Attempt to create new single encoding container when already previously encoded at this path.")
+            return InvalidSingleEncodingContainer(context: context, codingPath: codingPath)
+        }
         return PlistWrapperEncoder.SingleEncoder(codingPath: codingPath, userInfo: userInfo, ref: ref)
     }
     

--- a/Sources/Tetra/Foundation/Codable/PlistWrapperEncoder.swift
+++ b/Sources/Tetra/Foundation/Codable/PlistWrapperEncoder.swift
@@ -154,7 +154,7 @@ extension PlistWrapperEncoder.SingleEncoder: SingleValueEncodingContainer {
     }
     
     func encodeNil() throws {
-        throw EncodingError.invalidValue(Never.self, .init(codingPath: codingPath, debugDescription: "null is not allowed in propertylist"))
+        throw EncodingError.invalidValue(Optional<Any>.none as Any, .init(codingPath: codingPath, debugDescription: "null is not allowed in propertylist"))
     }
     
     func encode(_ value: Bool) throws {
@@ -243,7 +243,7 @@ extension PlistWrapperEncoder.SingleEncoder: SingleValueEncodingContainer {
 extension PlistWrapperEncoder.KeyedEncoder: KeyedEncodingContainerProtocol {
     
     func encodeNil(forKey key: Key) throws {
-        throw EncodingError.invalidValue(Never.self, .init(codingPath: codingPath + [key], debugDescription: "null is not allowed in propertyList"))
+        throw EncodingError.invalidValue(Optional<Any>.none as Any, .init(codingPath: codingPath + [key], debugDescription: "null is not allowed in propertyList"))
     }
     
     func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
@@ -366,7 +366,7 @@ extension PlistWrapperEncoder.UnkeyedEncoder: UnkeyedEncodingContainer {
     }
     
     func encodeNil() throws {
-        throw EncodingError.invalidValue(Never.self, .init(codingPath: codingPath + [TetraCodingKey(index: count)], debugDescription: "null is not allowed in propertyList"))
+        throw EncodingError.invalidValue(Optional<Any>.none as Any, .init(codingPath: codingPath + [TetraCodingKey(index: count)], debugDescription: "null is not allowed in propertyList"))
     }
     
     mutating func encode<T>(_ value: T) throws where T : Encodable {


### PR DESCRIPTION
Since Plist/JsonWrapper Encoder is supposed to use for merging the encoding, there could be a case where precondition can be easily met. So it is reasonable to throw error rather than crash which is unrecoverable.


`MultiMapTask` will be the new version of TryMapTask and MapTask. This aims to the new Swift Feature `TypedThrow` and similar behavior of `flatMap` of `AsyncSequence` and `Combine` which can manage multiple intermediate producer. 
