### PR TITLE
reimplement mapTask family

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,10 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Tetra",
-            dependencies: []
+            dependencies: [],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency=complete"),
+            ]
         ),
         .testTarget(
             name: "TetraTests",

--- a/README.md
+++ b/README.md
@@ -139,4 +139,4 @@ struct ContentView: View {
 
 - This is because, Swift does not allow running task inline(run task until reaching suspending point)
 
-- To fix this issue, use `MapTask` or `TryMapTask` inside the `FlatMap`
+- To fix this issue, use `MapTask` or `TryMapTask` inside the `FlatMap` or attach `buffer` before `MapTask` and `TryMapTask`

--- a/Sources/Tetra/Combine/CompatAsyncThrowingPublisher.swift
+++ b/Sources/Tetra/Combine/CompatAsyncThrowingPublisher.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import Combine
+@preconcurrency import Combine
 
 public struct CompatAsyncThrowingPublisher<P:Publisher>: AsyncTypedSequence {
 

--- a/Sources/Tetra/Combine/DispatchTimePublisher.swift
+++ b/Sources/Tetra/Combine/DispatchTimePublisher.swift
@@ -109,9 +109,11 @@ extension DispatchTimePublisher {
         }
         
         func cancel() {
-            lock.withLock {
+            let _ = lock.withLock {
                 $0.request = .none
+                let sub = $0.subscriber
                 $0.subscriber = nil
+                return sub
             }
             source.cancel()
             source.setEventHandler(handler: nil)

--- a/Sources/Tetra/Combine/DispatchTimePublisher.swift
+++ b/Sources/Tetra/Combine/DispatchTimePublisher.swift
@@ -109,7 +109,7 @@ extension DispatchTimePublisher {
         }
         
         func cancel() {
-            let _ = lock.withLock {
+            let _ = lock.withLockUnchecked {
                 $0.request = .none
                 let sub = $0.subscriber
                 $0.subscriber = nil
@@ -135,7 +135,7 @@ extension DispatchTimePublisher {
         }
         
         func attach(_ subscriber:S) {
-            lock.withLock {
+            lock.withLockUnchecked {
                 $0.subscriber = subscriber
             }
             subscriber.receive(subscription: self)
@@ -143,7 +143,7 @@ extension DispatchTimePublisher {
         
         func fire(shouldFinish:Bool = false) {
             let time = DispatchTime.now()
-            let sub = lock.withLock{
+            let sub = lock.withLockUnchecked{
                 if $0.request > 0 {
                     $0.request -= 1
                 } else {

--- a/Sources/Tetra/Combine/ExperimentalMapTask.swift
+++ b/Sources/Tetra/Combine/ExperimentalMapTask.swift
@@ -48,15 +48,12 @@ internal struct MultiMapTask<Upstream:Publisher, Output:Sendable>: Publisher whe
     public let transform:@Sendable (Upstream.Output) async -> Result<Output,Failure>
     
     public func receive<S>(subscriber: S) where S : Subscriber, Upstream.Failure == S.Failure, Output == S.Input {
-        subscriber
-            .receive(
-                subscription: Inner(
-                    maxTasks: maxTasks,
-                    upstream: upstream, 
-                    subscriber: subscriber,
-                    transform: transform
-                )
-            )
+        let processor = Processor(maxTasks: maxTasks, subscriber: subscriber, transform: transform)
+        let task = Task {
+            await processor.run()
+        }
+        processor.resumeCondition(task)
+        upstream.subscribe(processor)
     }
     
     
@@ -76,117 +73,57 @@ internal struct MultiMapTask<Upstream:Publisher, Output:Sendable>: Publisher whe
 extension MultiMapTask: Sendable where Upstream: Sendable {}
 
 extension MultiMapTask {
+
+    struct TaskState<S:Subscriber> where S.Failure == Failure, S.Input == Output {
+        var demand = PendingDemandState(taskCount: 0, pendingDemand: .none)
+        var subscriber:S? = nil
+        var upstreamSubscription = SubscriptionContinuation.waiting
+        var condition = TaskValueContinuation.waiting
+    }
     
-    internal struct DelegateState<S:Subscriber> where S.Input == Output, S.Failure == Failure {
+    struct Processor<S:Subscriber>: CustomCombineIdentifierConvertible where S.Failure == Failure, S.Input == Output {
         
-        typealias AsyncSequenceSource = AsyncStream<Result<Upstream.Output,Failure>>
-        
-        let demandState: some UnfairStateLock<PendingDemandState> = createCheckedStateLock(checkedState: PendingDemandState(taskCount: 0, pendingDemand: .none))
-        let subscriberState: some UnfairStateLock<S?> = createUncheckedStateLock(uncheckedState: .none)
-        let buffer:DemandAsyncBuffer
         let maxTasks:Subscribers.Demand
-        let transform: @Sendable (Upstream.Output) async -> Result<Output,Failure>
+        let valueSource = AsyncStream<Result<Upstream.Output, Failure>>.makeStream()
+        let demandSource = AsyncStream<Subscribers.Demand>.makeStream()
+        let state: some UnfairStateLock<TaskState<S>> = createCheckedStateLock(checkedState: TaskState<S>())
+        let transform:@Sendable (Upstream.Output) async -> Result<Output,Failure>
+
+        let combineIdentifier = CombineIdentifier()
         
-        init(
-            buffer: DemandAsyncBuffer,
-            maxTasks: Subscribers.Demand,
-            subscriber:S,
-            transform: @Sendable @escaping (Upstream.Output) async -> Result<Output, Failure>
-        ) {
-            self.subscriberState.withLockUnchecked{ $0 = subscriber }
-            self.buffer = buffer
+        init(maxTasks:Subscribers.Demand, subscriber:S, transform: @escaping @Sendable (Upstream.Output) async -> Result<Output,Failure>) {
             self.maxTasks = maxTasks
             self.transform = transform
-        }
-        
-        struct PendingDemandState {
-            var taskCount:Int
-            var pendingDemand:Subscribers.Demand
-        }
-        
-        func processDemand(
-            demand:Subscribers.Demand,
-            subscription: any Subscription,
-            reduce:Bool = false
-        ){
-            if maxTasks == .unlimited {
-                subscription.request(demand)
-            } else {
-                let newDemand = demandState.withLock{
-                    if reduce {
-                        $0.taskCount -= 1
-                    }
-                    $0.pendingDemand += demand
-                    let availableSpace = maxTasks - $0.taskCount
-                    if $0.pendingDemand >= availableSpace {
-                        $0.pendingDemand -= availableSpace
-                        if let maxCount = availableSpace.max {
-                            $0.taskCount += maxCount
-                        } else {
-                            fatalError("availableSpace can not be unlimited while limit is bounded")
-                        }
-                        return availableSpace
-                    } else {
-                        let snapShot = $0.pendingDemand
-                        if let count = snapShot.max {
-                            $0.taskCount += count
-                            $0.pendingDemand = .none
-                        } else {
-                            // pendingDemand is smaller than availableSpace and limit is bounded and pendingDemand is infinite
-                            fatalError("pendingDemand can not be unlimited while limit is bounded")
-                        }
-                        return snapShot
-                    }
-                }
-                subscription.request(newDemand)
+            state.withLock{
+                $0.subscriber = subscriber
             }
-        }
-        
-        func dropSubscriber() {
-            // prevent the deinit while holding the lock
-            let _ = subscriberState.withLock{
-                let old = $0
-                $0 = nil
-                return old
-            }
-        }
-        
-        func receiveValue(_ value:Output) -> Subscribers.Demand? {
-            subscriberState.withLockUnchecked{ $0 }?.receive(value)
-        }
-        
-        func receiveComplete(_ completion:Subscribers.Completion<Failure>) {
-            subscriberState.withLockUnchecked{
-                let old = $0
-                $0 = nil
-                return old
-            }?.receive(completion: completion)
         }
         
         func localTask(
             subscription: any Subscription,
-            group: inout some CompatThrowingDiscardingTaskGroup,
-            stream: some NonThrowingAsyncSequence<Result<Upstream.Output, Failure>>
+            group: inout some CompatThrowingDiscardingTaskGroup
         ) async {
             group.addTask(priority: nil) {
-                for await demand in buffer {
-                    processDemand(demand: demand, subscription: subscription)
+                for await demand in demandSource.stream {
+                    let nextDemand = receive(demand: demand)
+                    subscription.request(nextDemand)
                 }
             }
-            var iterator = stream.makeAsyncIterator()
+            var iterator = valueSource.stream.makeAsyncIterator()
             while let upstreamValue = await iterator.next() {
                 switch upstreamValue {
                 case .failure(let failure):
-                    receiveComplete(.failure(failure))
+                    send(completion: .failure(failure))
                     break
                 case .success(let success):
                     let flag = group.addTaskUnlessCancelled(priority: nil) {
                         switch await transform(success) {
                         case .failure(let failure):
-                            receiveComplete(.failure(failure))
+                            send(completion: .failure(failure))
+                            throw CancellationError()
                         case .success(let value):
-                            if let demand = receiveValue(value) {
-                                processDemand(demand: demand, subscription: subscription, reduce: true)
+                            if let demand = send(value) {
+                                subscription.request(demand)
                             } else {
                                 throw CancellationError()
                             }
@@ -197,105 +134,184 @@ extension MultiMapTask {
                     }
                 }
             }
-            buffer.close()
         }
         
-        func makeSource(
-            upstream:Upstream
-        ) async -> (AsyncSequenceSource, Subscription)? {
-            let subscriptionLock = createCheckedStateLock(checkedState: SubscriptionContinuation.waiting)
-            let (stream, continuation) = AsyncSequenceSource.makeStream()
-            continuation.onTermination = { _ in
-                buffer.close()
+        func terminateStream() {
+            demandSource.continuation.finish()
+            valueSource.continuation.finish()
+        }
+        
+        func send(completion: Subscribers.Completion<Failure>?) {
+            let subscriber = state.withLock{
+                let old = $0.subscriber
+                $0.subscriber = nil
+                return old
             }
-            upstream
-                .subscribe(
-                    AnySubscriber(
-                        receiveSubscription: subscriptionLock.received,
-                        receiveValue: {
-                            continuation.yield(.success($0))
-                            return .none
-                        },
-                        receiveCompletion: {
-                            switch $0 {
-                            case .finished:
-                                break
-                            case .failure(let error):
-                                continuation.yield(.failure(error))
-                            }
-                            continuation.finish()
-                        }
-                    )
-                )
-            guard let subscription = await subscriptionLock.consumeSubscription()
-            else {
-                continuation.finish()
-                return nil
+            if let completion {
+                subscriber?.receive(completion: completion)
             }
+        }
+        
+        func send(_ value: S.Input) -> Subscribers.Demand? {
+            let newDemand = state.withLock{
+                $0.subscriber
+            }?.receive(value)
+            guard let newDemand else { return nil }
+            
+            if maxTasks == .unlimited {
+                return newDemand
+            }
+            return state.withLock{
+                $0.demand.transistion(maxTasks: maxTasks, newDemand, reduce: true)
+            }
+        }
+        
+        func receive(demand:Subscribers.Demand) -> Subscribers.Demand {
+            if maxTasks == .unlimited {
+                return demand
+            }
+            return state.withLock{
+                $0.demand.transistion(maxTasks: maxTasks, demand, reduce: false)
+            }
+        }
 
-            return (stream, subscription)
+        func waitForUpStream() async -> (any Subscription)? {
+            await withTaskCancellationHandler {
+                await withUnsafeContinuation { coninuation in
+                    state.withLock{
+                        $0.upstreamSubscription.transition(.suspend(coninuation))
+                    }?.run()
+                }
+            } onCancel: {
+                state.withLock{
+                    $0.upstreamSubscription.transition(.cancel)
+                }?.run()
+            }
+        }
+        
+        func resumeCondition(_ task:Task<Void,Never>) {
+            state.withLock{
+                $0.condition.transition(.resume(task))
+            }?.run()
+        }
+        
+        func waitForCondition() async throws {
+            try await withUnsafeThrowingContinuation{ continuation in
+                state.withLock{
+                    $0.condition.transition(.suspend(continuation))
+                }?.run()
+            }
+        }
+        
+        func clearCondition() {
+            state.withLock{
+                $0.condition.transition(.finish)
+            }?.run()
+        }
+        
+        func run() async {
+            let token:Void? = try? await waitForCondition()
+            if token == nil {
+                withUnsafeCurrentTask{
+                    $0?.cancel()
+                }
+            }
+            defer {
+                clearCondition()
+            }
+            let subscription = await waitForUpStream()
+            state.withLockUnchecked{
+                $0.subscriber
+            }?.receive(subscription: self)
+            guard let subscription else {
+                terminateStream()
+                return
+            }
+            await withTaskCancellationHandler {
+                if #available(iOS 17.0, tvOS 17.0, macCatalyst 17.0, macOS 14.0, watchOS 10.0, visionOS 1.0, *) {
+                    try? await withThrowingDiscardingTaskGroup(returning: Void.self) { group in
+                        await localTask(
+                            subscription: subscription,
+                            group: &group
+                        )
+                        terminateStream()
+                    }
+                } else {
+                    await withThrowingTaskGroup(of: Void.self, returning: Void.self) { group in
+                        let gIterator = group.makeAsyncIterator()
+                        async let subTask:() = {
+                            var iterator = gIterator
+                            while let _ = try? await iterator.next() {
+                                
+                            }
+                        }()
+                        await localTask(
+                            subscription: subscription,
+                            group: &group
+                        )
+                        terminateStream()
+                        await subTask
+                    }
+                }
+                send(completion: .finished)
+            } onCancel: {
+                subscription.cancel()
+                send(completion: nil)
+            }
         }
         
     }
     
-    private final class Inner:Subscription, CustomStringConvertible, CustomPlaygroundDisplayConvertible  {
-        
-        var description: String { "MultiMapTask" }
-        
-        var playgroundDescription: Any { description }
-        private let task:Task<Void,Never>
-        private let demander:DemandAsyncBuffer
+}
 
-        // TODO: Replace with Delegating StateHolder
-        fileprivate init<S:Subscriber>(
-            maxTasks:Subscribers.Demand,
-            upstream:Upstream,
-            subscriber:S,
-            transform: @escaping @Sendable (Upstream.Output) async -> Result<Output,Failure>
-        ) where S.Input == Output, S.Failure == Failure {
-            precondition(maxTasks != .none, "maxTasks can not be zero")
-            let buffer = DemandAsyncBuffer()
-            demander = buffer
-            let state = DelegateState(buffer: buffer, maxTasks: maxTasks, subscriber: subscriber, transform: transform)
-            task = Task {
-                guard let (stream, subscription) = await state.makeSource(upstream: upstream)
-                else { return }
-                await withTaskCancellationHandler {
-                    if #available(iOS 17.0, tvOS 17.0, macCatalyst 17.0, macOS 14.0, watchOS 10.0, visionOS 1.0, *) {
-                        try? await withThrowingDiscardingTaskGroup(returning: Void.self) { group in
-                            await state.localTask(subscription: subscription, group: &group, stream: stream)
-                        }
-                    } else {
-                        await withThrowingTaskGroup(of: Void.self, returning: Void.self) { group in
-                            let gIterator = group.makeAsyncIterator()
-                            async let subTask:() = {
-                                var iterator = gIterator
-                                while let _ = try? await iterator.next() {
-                                    
-                                }
-                            }()
-                            await state.localTask(subscription: subscription, group: &group, stream: stream)
-                            await subTask
-                        }
-                    }
-                    state.receiveComplete(.finished)
-                } onCancel: {
-                    subscription.cancel()
-                    state.dropSubscriber()
-                }
-            }
-        }
-        
-        func cancel() {
-            task.cancel()
-        }
-        
-        func request(_ demand: Subscribers.Demand) {
-            demander.append(element: demand)
-        }
-        
-        deinit { task.cancel() }
+
+extension MultiMapTask.Processor: Subscriber {
+    
+    func receive(_ input: Upstream.Output) -> Subscribers.Demand {
+        valueSource.continuation.yield(.success(input))
+        return .none
     }
+    
+    func receive(completion: Subscribers.Completion<Upstream.Failure>) {
+        switch completion {
+        case .finished:
+            break
+        case .failure(let failure):
+            valueSource.continuation.yield(.failure(failure))
+        }
+        valueSource.continuation.finish()
+    }
+    
+    typealias Input = Upstream.Output
+    
+    typealias Failure = Upstream.Failure
+    
+    func receive(subscription: any Subscription) {
+        state.withLock {
+            $0.upstreamSubscription.transition(.resume(subscription))
+        }?.run()
+    }
+
+}
+
+extension MultiMapTask.Processor: Subscription {
+    
+    func request(_ demand: Subscribers.Demand) {
+        demandSource.continuation.yield(demand)
+    }
+    
+    func cancel() {
+        state.withLock{
+            $0.condition.transition(.cancel)
+        }?.run()
+    }
+    
+}
+
+extension MultiMapTask.Processor: CustomStringConvertible, CustomPlaygroundDisplayConvertible {
+    
+    var description: String { "MultiMapTask" }
+    var playgroundDescription: Any { description }
     
     
 }

--- a/Sources/Tetra/Combine/ExperimentalMapTask.swift
+++ b/Sources/Tetra/Combine/ExperimentalMapTask.swift
@@ -9,29 +9,7 @@ import Foundation
 import Combine
 
 
-internal protocol CompatThrowingDiscardingTaskGroup {
-    
-    var isCancelled:Bool { get }
-    var isEmpty:Bool { get }
-    func cancelAll()
-    mutating func addTaskUnlessCancelled(
-        priority: TaskPriority?,
-        operation: @escaping @Sendable () async throws -> Void
-    ) -> Bool
-    mutating func addTask(
-        priority: TaskPriority?,
-        operation: @escaping @Sendable () async throws -> Void
-    )
 
-}
-@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, macCatalyst 17.0, visionOS 1.0, *)
-extension ThrowingDiscardingTaskGroup: CompatThrowingDiscardingTaskGroup {
-
-}
-
-extension ThrowingTaskGroup: CompatThrowingDiscardingTaskGroup where ChildTaskResult == Void {
-
-}
 
 /**
     Manage Multiple Child Task. provides similair behavior of `flatMap`'s `maxPublisher`

--- a/Sources/Tetra/Combine/PendingDemandState.swift
+++ b/Sources/Tetra/Combine/PendingDemandState.swift
@@ -1,0 +1,52 @@
+//
+//  File.swift
+//  
+//
+//  Created by 박병관 on 5/29/24.
+//
+
+import Foundation
+import Combine
+
+struct PendingDemandState {
+    var taskCount:Int
+    var pendingDemand:Subscribers.Demand
+    
+    
+    mutating func transistion(
+        maxTasks:Subscribers.Demand,
+        _ demand:Subscribers.Demand,
+        reduce:Bool = false
+    ) -> (Subscribers.Demand) {
+        if maxTasks == .unlimited {
+            return demand
+        }
+        if reduce {
+            taskCount -= 1
+        }
+        pendingDemand += demand
+        let availableSpace = maxTasks - taskCount
+        if pendingDemand >= availableSpace {
+            pendingDemand -= availableSpace
+            if let maxCount = availableSpace.max {
+                taskCount += maxCount
+            } else {
+                fatalError("availableSpace can not be unlimited while limit is bounded")
+            }
+            return availableSpace
+        } else {
+            let snapShot = pendingDemand
+            if let count = snapShot.max {
+                taskCount += count
+                pendingDemand = .none
+            } else {
+                // pendingDemand is smaller than availableSpace and limit is bounded and pendingDemand is infinite
+                fatalError("pendingDemand can not be unlimited while limit is bounded")
+            }
+            return snapShot
+        }
+    }
+
+
+    
+}

--- a/Sources/Tetra/Combine/Publishers+MapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+MapTask.swift
@@ -159,14 +159,13 @@ extension MapTask {
                 clearCondition()
             }
             let subscription = await waitForUpStream()
+            defer { terminateStream() }
             state.withLockUnchecked{
                 $0.subscriber
             }?.receive(subscription: self)
             guard let subscription else {
-                terminateStream()
                 return
             }
-            defer { terminateStream() }
             let stream = valueSource.stream.map{
                 switch $0 {
                 case .success(let value):

--- a/Sources/Tetra/Combine/Publishers+TryMapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+TryMapTask.swift
@@ -153,11 +153,10 @@ extension TryMapTask {
             state.withLockUnchecked{
                 $0.subscriber
             }?.receive(subscription: self)
+            defer { terminateStream() }
             guard let subscription else {
-                terminateStream()
                 return
             }
-            defer { terminateStream() }
             let stream = valueSource.stream.map(transform)
             await withTaskCancellationHandler {
                 var iterator = stream.makeAsyncIterator()

--- a/Sources/Tetra/Combine/Publishers+TryMapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+TryMapTask.swift
@@ -16,22 +16,24 @@ import _Concurrency
     **There is an issue when using with PassthroughSubject or CurrentValueSubject**
 
     - Since Swift does not support running Task inline way (run in sync until suspension point), Subject's value can lost.
-    - Use the workaround like below to prevent this kind of issue
+    - wrap the mapTask with `flatMap` or use `buffer` before `mapTask`
 
 ```
  import Combine
 
  let subject = PassthroughSubject<Int,Never>()
  subject.flatMap(maxPublishers: .max(1)) { value in
-     Just(value).mapTask{ \**do async job**\ }
+     Just(value).tryMapTask{ \**do async job**\ }
  }
+ subject.buffer(size: 1, prefetch: .keepFull, whenFull: .customError{ fatalError() })
+     .tryMapTask{ \**do async job**\ }
      
 ```
  */
 public struct TryMapTask<Upstream:Publisher, Output:Sendable>: Publisher where Upstream.Output:Sendable {
 
     public typealias Output = Output
-    public typealias Failure = Error
+    public typealias Failure = any Error
 
     public let upstream:Upstream
     public var transform:@Sendable (Upstream.Output) async throws -> Output
@@ -42,12 +44,13 @@ public struct TryMapTask<Upstream:Publisher, Output:Sendable>: Publisher where U
     }
     
     public func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
-        subscriber
-            .receive(
-                subscription: Inner(
-                    upstream: upstream, subscriber: subscriber, transform: transform
-                )
-            )
+        let processor = Processor(subscriber: subscriber, transform: transform)
+        let task = Task{
+           await processor.run()
+        }
+        processor.resumeCondition(task)
+        upstream.subscribe(processor)
+        
     }
 
 }
@@ -56,150 +59,198 @@ extension TryMapTask: Sendable where Upstream: Sendable {}
 
 extension TryMapTask {
     
+    internal struct TaskState<S:Subscriber> where S.Failure == Failure, S.Input == Output {
+        
+        var subscriber:S? = nil
+        var upstreamSubscription = SubscriptionContinuation.waiting
+        var condition = TaskValueContinuation.waiting
+    }
     
-    internal struct SubscriptionState<S:Subscriber> where S.Input == Output, S.Failure == Failure {
+    internal struct Processor<S:Subscriber>: CustomCombineIdentifierConvertible where S.Failure == Failure, S.Input == Output {
         
-        typealias AsyncSequenceSource = AsyncThrowingMapSequence<AsyncThrowingStream<Upstream.Output,Failure>, Output>
-        private let lock: some UnfairStateLock<S?> = createCheckedStateLock(checkedState: nil)
-        private let demandBuffer:DemandAsyncBuffer
+        let valueSource = AsyncThrowingStream<Upstream.Output,Failure>.makeStream(bufferingPolicy: .bufferingNewest(2))
+        let demandSource = AsyncStream<Subscribers.Demand>.makeStream()
+        let state: some UnfairStateLock<TaskState<S>> = createCheckedStateLock(checkedState: .init())
+        let transform:@Sendable (Upstream.Output) async throws -> Output
+        let combineIdentifier = CombineIdentifier()
         
-        init(demandBuffer: DemandAsyncBuffer, subscriber:S) {
-            self.demandBuffer = demandBuffer
-            self.lock.withLockUnchecked{ $0 = subscriber }
+        init(
+            subscriber:S,
+            transform: @escaping @Sendable (Upstream.Output) async throws -> Output
+        ) {
+            
+            self.transform = transform
+            state.withLock{ $0.subscriber = subscriber }
         }
         
-        func receive(_ input: S.Input) -> Subscribers.Demand? {
-            lock.withLockUnchecked{
-                $0
-            }?.receive(input)
-        }
-        
-        func receive(completion: Subscribers.Completion<Failure>) {
-            lock.withLockUnchecked{ 
-                let old = $0
-                $0 = nil
-                return old
-            }?.receive(completion: completion)
-        }
-        
-        func dropSubscriber() {
-            let _ = lock.withLockUnchecked{
-                let old = $0
-                $0 = nil
+        func send(completion: Subscribers.Completion<Failure>?) {
+            let subscriber = state.withLockUnchecked{
+                let old = $0.subscriber
+                $0.subscriber = nil
                 return old
             }
+            if let completion {
+                subscriber?.receive(completion: completion)
+            }
         }
         
-        func makeSource(
-            upstream:Upstream,
-            transform:@escaping @Sendable (Upstream.Output) async throws -> Output
-        ) async -> (AsyncSequenceSource, Subscription)? {
-            let subscriptionLock = createCheckedStateLock(checkedState: SubscriptionContinuation.waiting)
-            let (stream, continuation) = AsyncThrowingStream<Upstream.Output,Failure>.makeStream()
-            continuation.onTermination = { _ in
-                demandBuffer.close()
-            }
-            upstream
-                .subscribe(
-                    AnySubscriber(
-                        receiveSubscription: subscriptionLock.received,
-                        receiveValue: {
-                            continuation.yield($0)
-                            return .none
-                        },
-                        receiveCompletion: {
-                            switch $0 {
-                            case .finished:
-                                continuation.finish(throwing: .none)
-                            case .failure(let error):
-                                continuation.finish(throwing: error)
-                            }
-                        }
-                    )
-                )
-            guard let subscription = await subscriptionLock.consumeSubscription()
-            else {
-                continuation.finish()
-                return nil
-            }
-            return (stream.map(transform),subscription)
+        func send(_ value:Output) -> Subscribers.Demand? {
+            state.withLockUnchecked{
+                $0.subscriber
+            }?.receive(value)
+        }
+
+        func terminateStream() {
+            demandSource.continuation.finish()
+            valueSource.continuation.finish()
         }
         
-        func runTask(
-            _ source:AsyncSequenceSource,
-            _ subscription: any Subscription
-        ) async {
+        func waitForUpStream() async -> (any Subscription)? {
             await withTaskCancellationHandler {
-                var iterator = source.makeAsyncIterator()
-                do {
-                    for await var pending in demandBuffer {
-                        if pending == .none {
-                            subscription.request(.none)
-                            continue
-                        }
-                        while pending > .none {
-                            subscription.request(.max(1))
-                            pending -= 1
-                            guard
-                                let value = try await iterator.next(),
-                                let demand = receive(value)
-                            else {
+                await withUnsafeContinuation { coninuation in
+                    state.withLock{
+                        $0.upstreamSubscription.transition(.suspend(coninuation))
+                    }?.run()
+                }
+            } onCancel: {
+                state.withLock{
+                    $0.upstreamSubscription.transition(.cancel)
+                }?.run()
+            }
+        }
+        
+        func resumeCondition(_ task:Task<Void,Never>) {
+            state.withLock{
+                $0.condition.transition(.resume(task))
+            }?.run()
+        }
+        
+        func waitForCondition() async throws {
+            try await withUnsafeThrowingContinuation{ continuation in
+                state.withLock{
+                    $0.condition.transition(.suspend(continuation))
+                }?.run()
+            }
+        }
+        
+        func clearCondition() {
+            state.withLock{
+                $0.condition.transition(.finish)
+            }?.run()
+        }
+        
+        func run() async {
+            let token:Void? = try? await waitForCondition()
+            if token == nil {
+                withUnsafeCurrentTask{
+                    $0?.cancel()
+                }
+            }
+            defer {
+                clearCondition()
+            }
+            let subscription = await waitForUpStream()
+            state.withLockUnchecked{
+                $0.subscriber
+            }?.receive(subscription: self)
+            guard let subscription else {
+                terminateStream()
+                return
+            }
+            defer { terminateStream() }
+            let stream = valueSource.stream.map(transform)
+            await withTaskCancellationHandler {
+                var iterator = stream.makeAsyncIterator()
+                for await var demand in demandSource.stream {
+                    if demand == .none {
+                        subscription.request(.none)
+                        continue
+                    }
+                    while demand > .none {
+                        demand -= 1
+                        subscription.request(.max(1))
+                        do {
+                            guard let value = try await iterator.next() else {
+                                send(completion: .finished)
                                 return
                             }
-                            pending += demand
+                            guard let newDemand = send(value) else {
+                                return
+                            }
+                            demand += newDemand
+                        } catch {
+                            send(completion: .failure(error))
+                            return
                         }
                     }
-                } catch {
-                    receive(completion: .failure(error))
+                    
                 }
             } onCancel: {
                 subscription.cancel()
-                dropSubscriber()
+                send(completion: nil)
             }
-            receive(completion: .finished)
-            demandBuffer.close()
+
         }
-        
         
     }
+ 
     
-    private final class Inner<S:Subscriber>:Subscription, CustomStringConvertible, CustomPlaygroundDisplayConvertible where S.Input == Output, S.Failure == Failure {
-        
-        var description: String { "TryMapTask" }
-        
-        var playgroundDescription: Any { description }
-        
-        private let task:Task<Void,Never>
-        private let demander:DemandAsyncBuffer
-        
-        // TODO: Replace with Delegating StateHolder
-        fileprivate init(upstream:Upstream, subscriber:S, transform: @escaping @Sendable (Upstream.Output) async throws -> Output) {
-            let buffer = DemandAsyncBuffer()
-            let state = SubscriptionState(demandBuffer: buffer, subscriber: subscriber)
-            demander = buffer
-            task = Task {
-                guard let (stream, subscription) = await state.makeSource(upstream: upstream, transform: transform)
-                else { return }
-                await state.runTask(stream, subscription)
-            }
-        }
-        
-        func cancel() {
-            task.cancel()
-        }
-        
-        func request(_ demand: Subscribers.Demand) {
-            demander.append(element: demand)
-        }
-        
-        deinit {
-            task.cancel()
-        }
-        
+}
 
+extension TryMapTask.Processor: Subscription {
+    
+    func cancel() {
+        state.withLock{
+            $0.condition.transition(.cancel)
+        }?.run()
+    }
+    
+    func request(_ demand: Subscribers.Demand) {
+        demandSource.continuation.yield(demand)
     }
     
 }
+
+extension TryMapTask.Processor: Subscriber {
+    
+    func receive(subscription: any Subscription) {
+        state.withLock{
+            $0.upstreamSubscription.transition(.resume(subscription))
+        }?.run()
+    }
+    
+    func receive(_ input: Upstream.Output) -> Subscribers.Demand {
+        let result = valueSource.continuation.yield(input)
+        switch result {
+        case .enqueued, .terminated:
+            break
+        case .dropped:
+            preconditionFailure("Buffer overflow")
+        @unknown default:
+            fatalError("unknown case")
+        }
+        return .none
+    }
+    
+    func receive(completion: Subscribers.Completion<Upstream.Failure>) {
+        switch completion {
+        case .finished:
+            valueSource.continuation.finish()
+        case .failure(let failure):
+            valueSource.continuation.finish(throwing: failure)
+        }
+    }
+    
+}
+
+extension TryMapTask.Processor: CustomStringConvertible, CustomPlaygroundDisplayConvertible {
+    
+    var playgroundDescription: Any { description }
+    
+    var description: String { "TryMapTask" }
+    
+}
+
 
 extension Publishers {
     

--- a/Sources/Tetra/Combine/RunLoopScheduler.swift
+++ b/Sources/Tetra/Combine/RunLoopScheduler.swift
@@ -46,6 +46,7 @@ public final class RunLoopScheduler: Scheduler, @unchecked Sendable, Hashable {
 
     deinit {
         CFRunLoopSourceInvalidate(source)
+        CFRunLoopWakeUp(cfRunLoop)
     }
 
     public init(async: Void = (), config: Configuration = .init()) async {

--- a/Sources/Tetra/Combine/RunLoopScheduler.swift
+++ b/Sources/Tetra/Combine/RunLoopScheduler.swift
@@ -111,6 +111,22 @@ public final class RunLoopScheduler: Scheduler, @unchecked Sendable, Hashable {
         self.config = config
     }
     
+    @usableFromInline
+    struct Block: @unchecked Sendable {
+        
+        let block: () -> Void
+        
+        @usableFromInline
+        func callAsFunction() {
+            block()
+        }
+        
+        @usableFromInline
+        init(block: @escaping () -> Void) {
+            self.block = block
+        }
+        
+    }
 
     @inlinable
     nonisolated
@@ -122,14 +138,15 @@ public final class RunLoopScheduler: Scheduler, @unchecked Sendable, Hashable {
         _ action: @escaping () -> Void
     ) -> Cancellable {
         let timer:Timer
+        let block = Block(block: action)
         if config.keepAliveUntilFinish {
             let observer = createRetainToken()
             timer = .init(fire: date.date, interval: interval.timeInterval, repeats: true) { _ in
                 CFRunLoopObserverInvalidate(observer)
-                action()
+                block()
             }
         } else {
-            timer = .init(fire: date.date, interval: interval.timeInterval, repeats: true) { _ in action() }
+            timer = .init(fire: date.date, interval: interval.timeInterval, repeats: true) { _ in block() }
         }
         timer.tolerance = tolerance.timeInterval
         let cfTimer = timer as CFRunLoopTimer
@@ -148,15 +165,15 @@ public final class RunLoopScheduler: Scheduler, @unchecked Sendable, Hashable {
         _ action: @escaping () -> Void
     ) {
         let timer:Timer
-        
+        let block = Block(block: action)
         if config.keepAliveUntilFinish {
             let observer = createRetainToken()
             timer = .init(fire: date.date, interval: 0, repeats: false) { _ in
                 CFRunLoopObserverInvalidate(observer)
-                action()
+                block()
             }
         } else {
-            timer = .init(fire: date.date, interval: 0, repeats: false) { _ in action() }
+            timer = .init(fire: date.date, interval: 0, repeats: false) { _ in block() }
         }
         timer.tolerance = tolerance.timeInterval
         CFRunLoopAddTimer(cfRunLoop, timer as CFRunLoopTimer, .commonModes)

--- a/Sources/Tetra/Combine/RunLoopScheduler.swift
+++ b/Sources/Tetra/Combine/RunLoopScheduler.swift
@@ -5,7 +5,7 @@
 //  Created by pbk on 2022/12/10.
 //
 
-import Foundation
+@preconcurrency import Foundation
 import Dispatch
 import os
 import Combine

--- a/Sources/Tetra/Combine/SchedulerTimePublisher.swift
+++ b/Sources/Tetra/Combine/SchedulerTimePublisher.swift
@@ -102,11 +102,13 @@ public struct SchedulerTimePublisher<T:Scheduler>: Publisher {
         }
         
         func cancel() {
-            let token = lock.withLockUnchecked{
+            let (_, token) = lock.withLockUnchecked{
                 let cancellable = $0.token
                 $0.token = .finished
                 $0.request = .none
-                return cancellable
+                let sub = $0.subscriber
+                $0.subscriber = nil
+                return (sub, cancellable)
             }
             if case let .cancellable(cancellable) = token {
                 cancellable.cancel()

--- a/Sources/Tetra/Combine/SchedulerTimePublisher.swift
+++ b/Sources/Tetra/Combine/SchedulerTimePublisher.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import Combine
+@preconcurrency import Combine
 
 
 public struct SchedulerTimePublisher<T:Scheduler>: Publisher {
@@ -55,7 +55,7 @@ public struct SchedulerTimePublisher<T:Scheduler>: Publisher {
         
         init(publisher: SchedulerTimePublisher<T>, subscriber:S) {
             self.publisher = publisher
-            lock.withLock{
+            lock.withLockUnchecked {
                 $0.subscriber = subscriber
             }
         }
@@ -69,7 +69,7 @@ public struct SchedulerTimePublisher<T:Scheduler>: Publisher {
                 let token = publisher.scheduler.schedule(after: publisher.scheduler.now, interval: publisher.interval, tolerance: publisher.tolerance ?? publisher.scheduler.minimumTolerance, options: publisher.options) { [weak self] in
                     self?.fire()
                 }
-                let oldValue = lock.withLock{
+                let oldValue = lock.withLockUnchecked{
                     let oldValue = $0.token
                     switch oldValue {
                     case .waiting, .cancellable:

--- a/Sources/Tetra/Combine/SubscriptionContinuation.swift
+++ b/Sources/Tetra/Combine/SubscriptionContinuation.swift
@@ -16,87 +16,116 @@ internal enum SubscriptionContinuation {
     case suspending(UnsafeContinuation<Subscription?,Never>)
     case finished
     
+    enum Event {
+        case resume(any Subscription)
+        case suspend(UnsafeContinuation<Subscription?, Never>)
+        case cancel
+    }
+    
+    enum Effect {
+        case drop(any Subscription)
+        case resume(UnsafeContinuation<Subscription?,Never>, any Subscription)
+        case cancel(UnsafeContinuation<Subscription?,Never>)
+        
+        func run() {
+            switch self {
+            case .drop(let subscription):
+                subscription.cancel()
+            case .resume(let unsafeContinuation, let subscription):
+                unsafeContinuation.resume(returning: subscription)
+            case .cancel(let unsafeContinuation):
+                unsafeContinuation.resume(returning: nil)
+            }
+        }
+    }
+    
+    mutating func transition(_ event:Event) -> Effect? {
+        switch event {
+        case .resume(let subscription):
+            return resume(subscription)
+        case .suspend(let unsafeContinuation):
+            return suspend(unsafeContinuation)
+        case .cancel:
+            return cancel()
+        }
+    }
+    
+
+    private mutating func resume(_ subscription: any Subscription) -> Effect? {
+        switch self {
+        case .waiting:
+            self = .cached(subscription)
+            return nil
+        case .cached(let oldValue):
+            self = .cached(subscription)
+            assertionFailure("received subscption more than once")
+            return .drop(oldValue)
+        case .suspending(let unsafeContinuation):
+            self = .finished
+            return .resume(unsafeContinuation, subscription)
+        case .finished:
+            return nil
+        }
+    }
+    
+    private mutating func suspend(_ continuation: UnsafeContinuation<Subscription?, Never>) -> Effect? {
+        switch self {
+        case .waiting:
+            self = .suspending(continuation)
+            return nil
+        case .cached(let subscription):
+            self = .finished
+            return .resume(continuation, subscription)
+        case .suspending(let oldValue):
+            self = .suspending(continuation)
+            assertionFailure("received continuation more than once")
+
+            return .cancel(oldValue)
+        case .finished:
+            
+            return .cancel(continuation)
+        }
+    }
+    
+    private mutating func cancel() -> Effect? {
+        switch self {
+        case .waiting:
+            self = .finished
+            return nil
+        case .cached(let subscription):
+            self = .finished
+            return .drop(subscription)
+        case .suspending(let unsafeContinuation):
+            self = .finished
+            return .cancel(unsafeContinuation)
+        case .finished:
+            return nil
+        }
+    }
+    
 }
 
 internal extension UnfairStateLock where State == SubscriptionContinuation {
     
     @usableFromInline
     func received(_ subscription:Subscription) {
-        let snapShot = withLock{
-            let oldValue = $0
-            switch oldValue {
-            case .waiting:
-                $0 = .cached(subscription)
-            case .cached(_):
-                $0 = .cached(subscription)
-            case .suspending(_):
-                break
-            case .finished:
-                break
-            }
-            return oldValue
-        }
-        switch snapShot {
-        case .waiting:
-            break
-        case .cached(let oldValue):
-            assertionFailure("received subscption more than once")
-            oldValue.cancel()
-        case .suspending(let continuation):
-            continuation.resume(returning: subscription)
-        case .finished:
-            subscription.cancel()
-        }
+        withLock {
+            $0.transition(.resume(subscription))
+        }?.run()
     }
     
     @usableFromInline
     func consumeSubscription() async -> Subscription? {
         await withTaskCancellationHandler {
             await withUnsafeContinuation{ continuation in
-                let snapShot = withLock{
-                    let oldValue = $0
-                    switch oldValue {
-                    case .waiting:
-                        $0 = .suspending(continuation)
-                    case .cached(_):
-                        $0 = .finished
-                    case .suspending(_):
-                        $0 = .suspending(continuation)
-                    case .finished:
-                        break
-                    }
-                    return oldValue
-                }
-                switch snapShot {
-                    
-                case .waiting:
-                    break
-                case .cached(let subscription):
-                    continuation.resume(returning: subscription)
-                case .suspending(let oldValue):
-                    assertionFailure("received continuation more than once")
-                    oldValue.resume(returning: nil)
-                case .finished:
-                    continuation.resume(returning: nil)
-                }
+                withLock {
+                    $0.transition(.suspend(continuation))
+                }?.run()
             }
         } onCancel: {
-            let snapShot = withLock{
-                let oldValue = $0
-                $0 = .finished
-                return oldValue
-            }
-            switch snapShot {
-                
-            case .waiting:
-                break
-            case .cached(let cancellable):
-                cancellable.cancel()
-            case .suspending(let continuation):
-                continuation.resume(returning: nil)
-            case .finished:
-                break
-            }
+            withLock {
+                $0.transition(.cancel)
+            }?.run()
         }
     }
     

--- a/Sources/Tetra/Concurrency/AsyncSequencePublisher.swift
+++ b/Sources/Tetra/Concurrency/AsyncSequencePublisher.swift
@@ -65,7 +65,7 @@ extension AsyncSequencePublisher {
         
         func dropSubscriber() {
             // try not to dealloc while holding the lock for safety
-            let _ = lock.withLock{
+            let _ = lock.withLockUnchecked{
                 let oldValue = $0
                 $0 = nil
                 return oldValue

--- a/Sources/Tetra/Concurrency/AsyncTypedSequence.swift
+++ b/Sources/Tetra/Concurrency/AsyncTypedSequence.swift
@@ -35,7 +35,7 @@ public struct WrappedAsyncSequence<Element>:AsyncSequence {
     }
     
     public typealias AsyncIterator = Iterator
-    private let builder: @Sendable () -> AsyncIterator
+    private let builder: () -> AsyncIterator
     
     internal init<T:AsyncSequence>(base:T) where T.Element == Element, T.AsyncIterator: NonThrowingAsyncIteratorProtocol {
         builder = { [base] in

--- a/Sources/Tetra/Concurrency/CompatDiscardigTaskGroup.swift
+++ b/Sources/Tetra/Concurrency/CompatDiscardigTaskGroup.swift
@@ -6,3 +6,27 @@
 //
 
 import Foundation
+
+internal protocol CompatThrowingDiscardingTaskGroup {
+    
+    var isCancelled:Bool { get }
+    var isEmpty:Bool { get }
+    func cancelAll()
+    mutating func addTaskUnlessCancelled(
+        priority: TaskPriority?,
+        operation: @escaping @Sendable () async throws -> Void
+    ) -> Bool
+    mutating func addTask(
+        priority: TaskPriority?,
+        operation: @escaping @Sendable () async throws -> Void
+    )
+
+}
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, macCatalyst 17.0, visionOS 1.0, *)
+extension ThrowingDiscardingTaskGroup: CompatThrowingDiscardingTaskGroup {
+
+}
+
+extension ThrowingTaskGroup: CompatThrowingDiscardingTaskGroup where ChildTaskResult == Void {
+
+}

--- a/Sources/Tetra/Concurrency/DemandAsyncBuffer.swift
+++ b/Sources/Tetra/Concurrency/DemandAsyncBuffer.swift
@@ -31,7 +31,7 @@ struct DemandAsyncBuffer: AsyncSequence, Sendable {
         continuation = tuple.continuation
     }
     
-    func append(element: __owned Element) {
+    func append(element:  Element) {
         continuation.yield(element)
     }
     

--- a/Sources/Tetra/Concurrency/Dispatch+Extension.swift
+++ b/Sources/Tetra/Concurrency/Dispatch+Extension.swift
@@ -5,7 +5,7 @@
 //  Created by pbk on 2023/01/26.
 //
 
-import Foundation
+@preconcurrency import Foundation
 import Dispatch
 
 public extension TetraExtension where Base == Task<Never,Never> {

--- a/Sources/Tetra/Concurrency/DispatchSerialExecutor.swift
+++ b/Sources/Tetra/Concurrency/DispatchSerialExecutor.swift
@@ -68,10 +68,12 @@ public final class DispatchQueueExecutor: SerialExecutor {
                 executor.enqueue(ExecutorJob(job))
                 return
             }
+            
             return executor.enqueue(job)
         }
+        let executor = asUnownedSerialExecutor()
         queue.async {
-            job.runSynchronously(on: self.asUnownedSerialExecutor())
+            job.runSynchronously(on: executor)
         }
     }
 #else
@@ -80,8 +82,9 @@ public final class DispatchQueueExecutor: SerialExecutor {
             return executor.enqueue(job)
         }
         let unownedJob = UnownedJob(job)
+        let executor = asUnownedSerialExecutor()
         queue.async {
-            unownedJob.runSynchronously(on: self.asUnownedSerialExecutor())
+            unownedJob.runSynchronously(on: executor)
         }
     }
 #endif

--- a/Sources/Tetra/Concurrency/Notification+AsyncSequence.swift
+++ b/Sources/Tetra/Concurrency/Notification+AsyncSequence.swift
@@ -32,7 +32,7 @@ public extension NotificationCenter {
 @available(iOS 15.0, tvOS 15.0, macCatalyst 15.0, watchOS 8.0, macOS 12.0, *)
 extension NotificationCenter.Notifications.AsyncIterator: NonThrowingAsyncIteratorProtocol {}
 
-public final class NotificationSequence: AsyncSequence {
+public final class NotificationSequence: AsyncSequence, Sendable {
     
     public typealias Element = Notification
     public typealias AsyncIterator = Iterator
@@ -97,7 +97,7 @@ public final class NotificationSequence: AsyncSequence {
     
     @Sendable
     func cancel() {
-        let snapShot = lock.withLock {
+        let snapShot = lock.withLockUnchecked {
             let oldValue = $0
             $0.observer = nil
             $0.buffer = []

--- a/Sources/Tetra/Concurrency/RunLoopExecutor.swift
+++ b/Sources/Tetra/Concurrency/RunLoopExecutor.swift
@@ -5,7 +5,7 @@
 //  Created by 박병관 on 8/20/23.
 //
 
-import Foundation
+@preconcurrency import Foundation
 
 internal struct RunLoopRunner: ~Copyable, @unchecked Sendable {
     

--- a/Sources/Tetra/Concurrency/RunLoopExecutor.swift
+++ b/Sources/Tetra/Concurrency/RunLoopExecutor.swift
@@ -60,7 +60,7 @@ public final class RunLoopExecutor: SerialExecutor {
     
     public func enqueue(_ job: consuming ExecutorJob) {
         let ref = UnownedJob(job)
-        let executor = self.asUnownedSerialExecutor()
+        let executor = asUnownedSerialExecutor()
         runner.submit {
             ref.runSynchronously(on: executor)
         }
@@ -69,6 +69,10 @@ public final class RunLoopExecutor: SerialExecutor {
     
     public func isSameExclusiveExecutionContext(other: RunLoopExecutor) -> Bool {
         return runner.thread == other.runner.thread
+    }
+    
+    public func checkIsolation() {
+        precondition(runner.thread == Thread.current, "Expected \(runner.thread) but found \(Thread.current)")
     }
     
 
@@ -104,7 +108,7 @@ public final class LegacyRunLoopExecutor: SerialExecutor {
     
     #if os(macOS) || os(tvOS) || os(watchOS) || os(iOS)
     public func enqueue(_ job: UnownedJob) {
-        let executor = UnownedSerialExecutor(ordinary: self)
+        let executor = asUnownedSerialExecutor()
         runner.submit {
             job.runSynchronously(on: executor)
         }

--- a/Sources/Tetra/Concurrency/TaskValueContinuation.swift
+++ b/Sources/Tetra/Concurrency/TaskValueContinuation.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 internal
-enum TaskValueContinuation {
+enum TaskValueContinuation: Sendable {
     
     case waiting
     case suspending(UnsafeContinuation<Void,any Error>)
@@ -16,14 +16,14 @@ enum TaskValueContinuation {
     case cancelled
     case finished
     
-    enum Event {
+    enum Event: Sendable {
         case suspend(UnsafeContinuation<Void,any Error>)
         case resume(Task<Void,Never>)
         case finish
         case cancel
     }
     
-    enum Effect {
+    enum Effect: Sendable {
         case raise(UnsafeContinuation<Void,any Error>)
         case resume(UnsafeContinuation<Void,any Error>)
         case cancel(Task<Void,Never>)

--- a/Sources/Tetra/Concurrency/TaskValueContinuation.swift
+++ b/Sources/Tetra/Concurrency/TaskValueContinuation.swift
@@ -1,0 +1,131 @@
+//
+//  File.swift
+//  
+//
+//  Created by 박병관 on 5/29/24.
+//
+
+import Foundation
+
+internal
+enum TaskValueContinuation {
+    
+    case waiting
+    case suspending(UnsafeContinuation<Void,any Error>)
+    case cached(Task<Void,Never>)
+    case cancelled
+    case finished
+    
+    enum Event {
+        case suspend(UnsafeContinuation<Void,any Error>)
+        case resume(Task<Void,Never>)
+        case finish
+        case cancel
+    }
+    
+    enum Effect {
+        case raise(UnsafeContinuation<Void,any Error>)
+        case resume(UnsafeContinuation<Void,any Error>)
+        case cancel(Task<Void,Never>)
+        
+        func run() {
+            switch self {
+            case .raise(let unsafeContinuation):
+                unsafeContinuation.resume(throwing: CancellationError())
+            case .resume(let unsafeContinuation):
+                unsafeContinuation.resume()
+            case .cancel(let task):
+                task.cancel()
+            }
+        }
+    }
+    
+    mutating func transition(_ event:Event) -> Effect? {
+        switch event {
+        case .suspend(let unsafeContinuation):
+            return suspend(unsafeContinuation)
+        case .resume(let task):
+            return resume(task)
+        case .finish:
+            return onFinish()
+        case .cancel:
+            return onCancel()
+        }
+    }
+    
+    private mutating func suspend(_ continuation:UnsafeContinuation<Void,any Error>) -> Effect? {
+        switch self {
+        case .waiting:
+            self = .suspending(continuation)
+            return nil
+        case .suspending(let oldValue):
+            self = .suspending(continuation)
+            assertionFailure("received continuation more than Once")
+
+            return .raise(oldValue)
+        case .cancelled:
+            return .raise(continuation)
+        case .cached(_):
+            fallthrough
+        case .finished:
+            return .resume(continuation)
+        }
+    }
+    
+    private mutating func resume(_ task:Task<Void,Never>) -> Effect? {
+        switch self {
+        case .waiting:
+            self = .cached(task)
+            return nil
+        case .suspending(let unsafeContinuation):
+            self = .cached(task)
+            return .resume(unsafeContinuation)
+        case .cancelled:
+            return .cancel(task)
+        case .cached(let oldValue):
+            self = .cached(task)
+            assertionFailure("can not handle Task on cached state")
+            return .cancel(oldValue)
+        case .finished:
+            return nil
+        }
+    }
+    
+    private mutating func onCancel() -> Effect? {
+        switch self {
+        case .cancelled:
+            fallthrough
+        case .waiting:
+            self = .cancelled
+            fallthrough
+        case .finished:
+            return nil
+        case .suspending(let unsafeContinuation):
+            self = .cancelled
+            return .raise(unsafeContinuation)
+        case .cached(let task):
+            self = .cancelled
+            return .cancel(task)
+        }
+    }
+    
+    private mutating func onFinish() -> Effect? {
+        switch self {
+        case .suspending(let unsafeContinuation):
+            self = .finished
+            return .resume(unsafeContinuation)
+        case .cached(_):
+            fallthrough
+        case .waiting:
+            self = .finished
+            fallthrough
+        case .cancelled:
+            fallthrough
+        case .finished:
+            return nil
+        }
+    }
+    
+
+    
+}

--- a/Sources/Tetra/Foundation/Codable/JsonWrapperEncoder.swift
+++ b/Sources/Tetra/Foundation/Codable/JsonWrapperEncoder.swift
@@ -506,14 +506,18 @@ final class JSONReference {
     static func string(_ str: String) -> JSONReference { .init(.primitive(.string(str))) }
     static func integer<T:FixedWidthInteger>(_ str: T) -> JSONReference { .init(.primitive(.integer(Int(str)))) }
     static func float<T:BinaryFloatingPoint>(_ number:T) -> JSONReference { .init(.primitive(.double(number.isSignalingNaN ? .signalingNaN : Double(number))))}
+    nonisolated(unsafe)
     static let `true` : JSONReference = .init(.primitive(.bool(true)))
+    nonisolated(unsafe)
     static let `false` : JSONReference = .init(.primitive(.bool(false)))
     static func bool(_ b: Bool) -> JSONReference { b ? .true : .false }
     static var emptyArray : JSONReference { .init(.array([])) }
     static var emptyObject : JSONReference { .init(.object([:])) }
+    
     static var emptyContainer: JSONReference {
         let item = JSONReference.null
         item.backing = nil
         return item
     }
+    
 }

--- a/Sources/Tetra/Foundation/Codable/PlistWrapper.swift
+++ b/Sources/Tetra/Foundation/Codable/PlistWrapper.swift
@@ -419,7 +419,7 @@ extension PlistWrapper: SerializableMappingProtocol {
             // unknown CF Plist object possibly CFKeyedArchiverUID?
             let typeId = CFGetTypeID(value)
             let typeDescription = CFCopyTypeIDDescription(typeId) as String
-            let instanceDescription = CFCopyDescription(value) as String
+//            let instanceDescription = CFCopyDescription(value) as String
             let context = DecodingError.Context(codingPath: path, debugDescription: "\(typeDescription) is not supported ")
             throw DecodingError.typeMismatch(Self.self, context)
         default:

--- a/Sources/Tetra/SwiftUI/RefreshableScrollView.swift
+++ b/Sources/Tetra/SwiftUI/RefreshableScrollView.swift
@@ -113,7 +113,7 @@ struct RefreshActionModifier: EnvironmentalModifier {
         @usableFromInline
         var refreshing:Bool
         @usableFromInline
-        var action:(@Sendable () async -> ())?
+        var action:( () async -> ())?
         
         @usableFromInline
         func body(content: Content) -> some View {
@@ -175,13 +175,13 @@ internal struct ScrollRefreshImp: UIViewRepresentable {
     @usableFromInline
     var refreshing:Bool
     @usableFromInline
-    let operation:@Sendable () async -> Void
+    let operation: () async -> Void
     
     @usableFromInline
     internal init(
         task: Binding<Task<Void, Never>?>,
         refreshing: Bool,
-        operation: @escaping @Sendable () async -> Void
+        operation: @escaping () async -> Void
     ) {
         self._task = task
         self.refreshing = refreshing
@@ -263,7 +263,7 @@ internal final class RefreshingCoordinator: NSObject {
     @usableFromInline
     @objc func refresh() {
         parent.task?.cancel()
-        parent.task = Task(operation: parent.operation)
+        parent.task = Task{  await parent.operation() }
     }
     
 }

--- a/Sources/Tetra/TetraExtension.swift
+++ b/Sources/Tetra/TetraExtension.swift
@@ -6,9 +6,14 @@
 //
 
 import Foundation
+
 public struct TetraExtension<Base> {
-    public var base:Base
+    
+    public internal(set) var base:Base
+    
     public init(base: Base) {
         self.base = base
     }
 }
+
+extension TetraExtension: Sendable where Base:Sendable {}


### PR DESCRIPTION
- reimplement MapTask family using state machine based algorithm.
- delay `receiveSubscription` to downstream until publisher becomes ready
- `buffer` is another operator which can handle direct subject when using with MapTask Family