### PR TITLE
MapTask: fix temporal race condition and propagate cancellation 

### DIFF
--- a/Sources/Tetra/Combine/AsyncSubscriberState.swift
+++ b/Sources/Tetra/Combine/AsyncSubscriberState.swift
@@ -56,21 +56,27 @@ struct AsyncSubscriberState<Input, Failure:Error> {
     enum Effect {
         
         case resumeValue(Continuation, Input)
-        case resumeFailure([Continuation], Failure)
+        case resumeFailure([Continuation], Failure, discard: (any Subscription)?)
         case request(any Subscription, Subscribers.Demand)
         case cancel([Continuation], (any Subscription)?)
+        case cancelAndDiscard([Continuation], discard: (any Subscription)?)
+        case discard((any Subscription)?)
         
         @usableFromInline
         consuming func run() {
             switch consume self {
+            case .discard:
+                break
             case .resumeValue(let continuation, let input):
                 continuation.resume(returning: .success(input))
             case .request(let subscription, let demand):
                 subscription.request(demand)
+            case .cancelAndDiscard(let array, discard: _):
+                array.forEach{ $0.resume(returning: nil) }
             case .cancel(let array, let subscription):
                 array.forEach{ $0.resume(returning: nil) }
                 subscription?.cancel()
-            case .resumeFailure(let array, let failure):
+            case .resumeFailure(let array, let failure, _):
                 array[0].resume(returning: .failure(failure))
                 array.dropFirst().forEach{ $0.resume(returning: nil) }
             }
@@ -98,15 +104,20 @@ struct AsyncSubscriberState<Input, Failure:Error> {
     private mutating func resume(completion: Subscribers.Completion<Failure>) -> Effect? {
         let jobs = pending
         pending.removeAll()
+        let oldSubscription = if case let .subscribed(token) = subscription {
+            token
+        } else {
+            nil as (any Subscription)?
+        }
         switch subscription {
         case .awaitingSubscription, .subscribed:
             if !jobs.isEmpty {
                 subscription = .terminal(nil)
                 switch completion {
                 case .finished:
-                    return .cancel(jobs, nil)
+                    return .cancelAndDiscard(jobs, discard: oldSubscription)
                 case .failure(let failure):
-                    return .resumeFailure(jobs, failure)
+                    return .resumeFailure(jobs, failure, discard: oldSubscription)
                 }
             } else {
                 switch completion {
@@ -115,7 +126,7 @@ struct AsyncSubscriberState<Input, Failure:Error> {
                 case .failure(let failure):
                     subscription = .terminal(failure)
                 }
-                return nil
+                return .discard(oldSubscription)
             }
         case .terminal:
             return .cancel(jobs, nil)
@@ -147,7 +158,7 @@ struct AsyncSubscriberState<Input, Failure:Error> {
             return .cancel([continuation], nil)
         case .terminal(let failure?):
             subscription = .terminal(nil)
-            return .resumeFailure([continuation], failure)
+            return .resumeFailure([continuation], failure, discard: nil)
         }
     }
     

--- a/Sources/Tetra/Combine/Publishers+MapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+MapTask.swift
@@ -190,7 +190,9 @@ extension MapTask {
                         case .success(let value):
                             upstreamValue = value
                         }
-                        switch (await transform(upstreamValue)) {
+                        // enqueue to separate task to prevent transformer cancelling root task using `UnsafeCurrentTask`
+                        async let job = transform(upstreamValue)
+                        switch (await job) {
                         case .success(let value):
                             if let newDemand = send(value) {
                                 demand += newDemand

--- a/Sources/Tetra/Combine/Publishers+MapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+MapTask.swift
@@ -90,12 +90,19 @@ extension MapTask {
             state.withLockUnchecked{ $0.subscriber = subscriber }
         }
         
-        private func send(completion: Subscribers.Completion<Failure>?) {
-            let subscriber = state.withLockUnchecked{
+        private func send(completion: Subscribers.Completion<Failure>?, cancel:Bool = false) {
+            terminateStream()
+            let (subscriber, effect) = state.withLockUnchecked{
                 let old = $0.subscriber
                 $0.subscriber = nil
-                return old
+                let effect = if cancel {
+                    $0.condition.transition(.cancel)
+                } else {
+                    $0.condition.transition(.finish)
+                }
+                return (old, effect)
             }
+            effect?.run()
             if let completion {
                 subscriber?.receive(completion: completion)
             }
@@ -165,21 +172,25 @@ extension MapTask {
             guard let subscription else {
                 return
             }
-            let stream = valueSource.stream.map{ [transform] in
-                switch $0 {
-                case .success(let value):
-                    return await transform(value)
-                case .failure(let failure):
-                    return .failure(failure)
-                }
-            }
             await withTaskCancellationHandler {
-                var iterator = stream.makeAsyncIterator()
+                var iterator =  valueSource.stream.makeAsyncIterator()
                 for await var demand in demandSource.stream {
                     while demand > .none {
                         demand -= 1
                         subscription.request(.max(1))
-                        switch (await iterator.next()) {
+                        let upstreamResult = await iterator.next()
+                        let upstreamValue:Upstream.Output
+                        switch upstreamResult {
+                        case .failure(let error):
+                            send(completion: .failure(error), cancel: false)
+                            return
+                        case .none:
+                            send(completion: .finished, cancel: false)
+                            return
+                        case .success(let value):
+                            upstreamValue = value
+                        }
+                        switch (await transform(upstreamValue)) {
                         case .success(let value):
                             if let newDemand = send(value) {
                                 demand += newDemand
@@ -187,10 +198,7 @@ extension MapTask {
                                 return
                             }
                         case .failure(let error):
-                            send(completion: .failure(error))
-                            return
-                        case .none:
-                            send(completion: .finished)
+                            send(completion: .failure(error), cancel: true)
                             return
                         }
                     }

--- a/Sources/Tetra/Combine/Publishers+TryMapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+TryMapTask.swift
@@ -81,12 +81,19 @@ extension TryMapTask {
             state.withLockUnchecked{ $0.subscriber = subscriber }
         }
         
-        private func send(completion: Subscribers.Completion<Failure>?) {
-            let subscriber = state.withLockUnchecked{
+        private func send(completion: Subscribers.Completion<Failure>?, cancel:Bool = false) {
+            terminateStream()
+            let (subscriber, effect) = state.withLockUnchecked{
                 let old = $0.subscriber
                 $0.subscriber = nil
-                return old
+                let effect = if cancel {
+                    $0.condition.transition(.cancel)
+                } else {
+                    $0.condition.transition(.finish)
+                }
+                return (old, effect)
             }
+            effect?.run()
             if let completion {
                 subscriber?.receive(completion: completion)
             }
@@ -156,24 +163,32 @@ extension TryMapTask {
             guard let subscription else {
                 return
             }
-            let stream = valueSource.stream.map(transform)
+            let stream = valueSource.stream
             await withTaskCancellationHandler {
                 var iterator = stream.makeAsyncIterator()
                 for await var demand in demandSource.stream {
                     while demand > .none {
                         demand -= 1
                         subscription.request(.max(1))
+                        let upstreamValue:Upstream.Output
                         do {
                             guard let value = try await iterator.next() else {
-                                send(completion: .finished)
+                                send(completion: .finished, cancel: false)
                                 return
                             }
+                            upstreamValue = value
+                        } catch {
+                            send(completion: .failure(error), cancel: false)
+                            return
+                        }
+                        do {
+                            let value = try await transform(upstreamValue)
                             guard let newDemand = send(value) else {
                                 return
                             }
                             demand += newDemand
                         } catch {
-                            send(completion: .failure(error))
+                            send(completion: .failure(error), cancel: true)
                             return
                         }
                     }

--- a/Sources/Tetra/Combine/Publishers+TryMapTask.swift
+++ b/Sources/Tetra/Combine/Publishers+TryMapTask.swift
@@ -182,7 +182,9 @@ extension TryMapTask {
                             return
                         }
                         do {
-                            let value = try await transform(upstreamValue)
+                            // enqueue to separate task to prevent transformer cancelling root task using `UnsafeCurrentTask`
+                            async let job = transform(upstreamValue)
+                            let value = try await job
                             guard let newDemand = send(value) else {
                                 return
                             }

--- a/Sources/Tetra/Foundation/ClosureHolder.swift
+++ b/Sources/Tetra/Foundation/ClosureHolder.swift
@@ -1,0 +1,33 @@
+//
+//  ClosureHolder.swift
+//  https://forums.swift.org/t/withoutactuallyescaping-async-functions/63198/12
+//
+//  Created by 박병관 on 6/8/24.
+//
+
+import Foundation
+#if canImport(CoreData)
+import CoreData
+#endif
+
+@usableFromInline
+final class ClosureHolder<R> {
+    @usableFromInline let closure: () throws -> R
+    
+    @inlinable
+    init(closure: @escaping  () throws -> R) {
+        self.closure = closure
+    }
+}
+
+#if canImport(CoreData)
+@usableFromInline
+final class CoreDataContextClosureHolder<R> {
+    @usableFromInline let closure: (NSManagedObjectContext) throws -> R
+    
+    @inlinable
+    init(closure: @escaping  (NSManagedObjectContext) throws -> R) {
+        self.closure = closure
+    }
+}
+#endif

--- a/Tests/TetraTests/TryMapTaskTests.swift
+++ b/Tests/TetraTests/TryMapTaskTests.swift
@@ -93,5 +93,27 @@ final class TryMapTaskTests: XCTestCase {
         wait(for: [expect], timeout: 0.5)
         bag.removeAll()
     }
+    
+    func testUnsafeCancel() throws {
+        let completion = expectation(description: "completion")
+        var array = [Int]()
+        let token = (0..<100)
+            .publisher
+            .tryMapTask { value in
+                await Task.yield()
+                withUnsafeCurrentTask {
+                    $0?.cancel()
+                }
+                return value
+            }.buffer(size: 1, prefetch: .keepFull, whenFull: .customError{ fatalError() })
+            .sink { _ in
+                completion.fulfill()
+            } receiveValue: {
+                array.append($0)
+            }
+        wait(for: [completion], timeout: 0.2)
+        XCTAssertEqual(array, Array(0..<100))
+        token.cancel()
+    }
 
 }


### PR DESCRIPTION
- discarding Subscription needs to be delayed until lock is unlocked
- When `MultiMapTask`, `TryMapTask` `MapTask` fails by the tranformer, operator should cancel upstream subscription
- wrap `TryMapTask` and `MapTask` transformer to `async let`, this will spawn the child task which will consume `UnsafeCurrent` cancellation this will prevent unwanted cancellation of root task.
